### PR TITLE
Add --path flag

### DIFF
--- a/corral/bundle/bundle.pony
+++ b/corral/bundle/bundle.pony
@@ -7,25 +7,24 @@ primitive BundleFile
   """
   Loader and creator of Bundle files.
   """
-  fun find_bundle_dir(env: Env, log: Log): (FilePath | None) =>
-    let cwd = Path.cwd()
-    var dir = cwd
-    while dir.size() > 0 do
-      log.fine("Looking for " + Files.bundle_filename() + " in: '" + dir + "'")
+  fun find_bundle_dir(env: Env, path: String, log: Log): (FilePath | None) =>
+    var path' = path
+    while path'.size() > 0 do
+      log.info("Looking for " + Files.bundle_filename() + " in: '" + path' + "'")
       try
-        let dir_path = FilePath(env.root as AmbientAuth, dir)?
-        let bundle_file = dir_path.join(Files.bundle_filename())?
+        let dir = FilePath(env.root as AmbientAuth, path')?
+        let bundle_file = dir.join(Files.bundle_filename())?
         if bundle_file.exists() then
-          return dir_path
+          return dir
         end
       end
-        dir = Path.split(dir)._1
+      path' = Path.split(path')._1
     end
-    log.info("corral.json not found, looked last in: '" + dir + "'")
+    log.info("corral.json not found, looked last in: '" + path' + "'")
     None
 
-  fun load_bundle(env: Env, log: Log): (Bundle | Error) =>
-    match find_bundle_dir(env, log)
+  fun load_bundle(env: Env, path: String, log: Log): (Bundle | Error) =>
+    match find_bundle_dir(env, path, log)
     | let dir: FilePath =>
       try
         Bundle.load(env, dir, log)?
@@ -38,9 +37,9 @@ primitive BundleFile
           + " in current working directory or ancestors.")
     end
 
-  fun create_bundle(env: Env, log: Log): (Bundle | Error) =>
+  fun create_bundle(env: Env, path: String, log: Log): (Bundle | Error) =>
     try
-      let dir = FilePath(env.root as AmbientAuth, Path.cwd())?
+      let dir = FilePath(env.root as AmbientAuth, path)?
       try Files.bundle_filepath(dir)?.remove() end
       Bundle.create(env, dir, log)
     else

--- a/corral/bundle/bundle.pony
+++ b/corral/bundle/bundle.pony
@@ -7,29 +7,29 @@ primitive BundleFile
   """
   Loader and creator of Bundle files.
   """
-  fun find_bundle_dir(env: Env, path: String, log: Log): (FilePath | None) =>
-    var path' = path
-    while path'.size() > 0 do
-      log.info("Looking for " + Files.bundle_filename() + " in: '" + path' + "'")
+  fun find_bundle_dir(env: Env, dir: String, log: Log): (FilePath | None) =>
+    var dir' = dir
+    while dir'.size() > 0 do
+      log.info("Looking for " + Files.bundle_filename() + " in: '" + dir' + "'")
       try
-        let dir_path = FilePath(env.root as AmbientAuth, path')?
+        let dir_path = FilePath(env.root as AmbientAuth, dir')?
         let bundle_file = dir_path.join(Files.bundle_filename())?
         if bundle_file.exists() then
           return dir_path
         end
       end
-      path' = Path.split(path')._1
+      dir' = Path.split(dir')._1
     end
-    log.info("corral.json not found, looked last in: '" + path' + "'")
+    log.info("corral.json not found, looked last in: '" + dir' + "'")
     None
 
-  fun load_bundle(env: Env, path: String, log: Log): (Bundle | Error) =>
-    match find_bundle_dir(env, path, log)
-    | let dir: FilePath =>
+  fun load_bundle(env: Env, dir: String, log: Log): (Bundle | Error) =>
+    match find_bundle_dir(env, dir, log)
+    | let dir': FilePath =>
       try
-        Bundle.load(env, dir, log)?
+        Bundle.load(env, dir', log)?
       else
-        Error("Error loading bundle files in " + dir.path)
+        Error("Error loading bundle files in " + dir'.path)
       end
     else
       Error(
@@ -37,11 +37,11 @@ primitive BundleFile
           + " in current working directory or ancestors.")
     end
 
-  fun create_bundle(env: Env, path: String, log: Log): (Bundle | Error) =>
+  fun create_bundle(env: Env, dir: String, log: Log): (Bundle | Error) =>
     try
-      let dir = FilePath(env.root as AmbientAuth, path)?
-      try Files.bundle_filepath(dir)?.remove() end
-      Bundle.create(env, dir, log)
+      let dir' = FilePath(env.root as AmbientAuth, dir)?
+      try Files.bundle_filepath(dir')?.remove() end
+      Bundle.create(env, dir', log)
     else
       Error(
         "Could not create " + Files.bundle_filename()

--- a/corral/bundle/bundle.pony
+++ b/corral/bundle/bundle.pony
@@ -12,10 +12,10 @@ primitive BundleFile
     while path'.size() > 0 do
       log.info("Looking for " + Files.bundle_filename() + " in: '" + path' + "'")
       try
-        let dir = FilePath(env.root as AmbientAuth, path')?
-        let bundle_file = dir.join(Files.bundle_filename())?
+        let dir_path = FilePath(env.root as AmbientAuth, path')?
+        let bundle_file = dir_path.join(Files.bundle_filename())?
         if bundle_file.exists() then
-          return dir
+          return dir_path
         end
       end
       path' = Path.split(path')._1

--- a/corral/cmd/cmd_add.pony
+++ b/corral/cmd/cmd_add.pony
@@ -1,6 +1,5 @@
 use "cli"
 use "json"
-use "files"
 use "../bundle"
 use "../util"
 

--- a/corral/cmd/cmd_add.pony
+++ b/corral/cmd/cmd_add.pony
@@ -19,7 +19,7 @@ primitive CmdAdd
       "\nadd: adding: " + dd.locator.string() + " "
         + dd.version.string() + " " + ld.revision.string())
 
-    match BundleFile.load_bundle(ctx.env, ctx.path, ctx.log)
+    match BundleFile.load_bundle(ctx.env, ctx.directory, ctx.log)
     | let bundle: Bundle =>
       try
         bundle.add_dep(dd, ld)

--- a/corral/cmd/cmd_add.pony
+++ b/corral/cmd/cmd_add.pony
@@ -1,5 +1,6 @@
 use "cli"
 use "json"
+use "files"
 use "../bundle"
 use "../util"
 
@@ -19,7 +20,7 @@ primitive CmdAdd
       "\nadd: adding: " + dd.locator.string() + " "
         + dd.version.string() + " " + ld.revision.string())
 
-    match BundleFile.load_bundle(ctx.env, ctx.log)
+    match BundleFile.load_bundle(ctx.env, ctx.path, ctx.log)
     | let bundle: Bundle =>
       try
         bundle.add_dep(dd, ld)

--- a/corral/cmd/cmd_clean.pony
+++ b/corral/cmd/cmd_clean.pony
@@ -7,7 +7,7 @@ primitive CmdClean
   fun apply(ctx: Context, cmd: Command) =>
     //ctx.log.info("clean: " + cmd.string())
 
-    match BundleFile.load_bundle(ctx.env, ctx.log)
+    match BundleFile.load_bundle(ctx.env, ctx.path, ctx.log)
     | let bundle: Bundle =>
       try
         let repos_dir = ctx.repo_cache

--- a/corral/cmd/cmd_clean.pony
+++ b/corral/cmd/cmd_clean.pony
@@ -7,7 +7,7 @@ primitive CmdClean
   fun apply(ctx: Context, cmd: Command) =>
     //ctx.log.info("clean: " + cmd.string())
 
-    match BundleFile.load_bundle(ctx.env, ctx.path, ctx.log)
+    match BundleFile.load_bundle(ctx.env, ctx.directory, ctx.log)
     | let bundle: Bundle =>
       try
         let repos_dir = ctx.repo_cache

--- a/corral/cmd/cmd_fetch.pony
+++ b/corral/cmd/cmd_fetch.pony
@@ -9,6 +9,7 @@ class CmdFetch
 
   new create(ctx': Context, cmd: Command) =>
     ctx = ctx'
+    //ctx.log.info("fetch: " + cmd.string())
     ctx.env.out.print("\nfetch:")
     match BundleFile.load_bundle(ctx.env, ctx.directory, ctx.log)
     | let bundle: Bundle =>

--- a/corral/cmd/cmd_fetch.pony
+++ b/corral/cmd/cmd_fetch.pony
@@ -9,8 +9,6 @@ class CmdFetch
 
   new create(ctx': Context, cmd: Command) =>
     ctx = ctx'
-    //ctx.log.info("fetch: " + cmd.string())
-
     ctx.env.out.print("\nfetch:")
     match BundleFile.load_bundle(ctx.env, ctx.path, ctx.log)
     | let bundle: Bundle =>

--- a/corral/cmd/cmd_fetch.pony
+++ b/corral/cmd/cmd_fetch.pony
@@ -10,7 +10,7 @@ class CmdFetch
   new create(ctx': Context, cmd: Command) =>
     ctx = ctx'
     ctx.env.out.print("\nfetch:")
-    match BundleFile.load_bundle(ctx.env, ctx.path, ctx.log)
+    match BundleFile.load_bundle(ctx.env, ctx.directory, ctx.log)
     | let bundle: Bundle =>
       fetch_bundle_deps(bundle, bundle)
     | let err: Error =>

--- a/corral/cmd/cmd_fetch.pony
+++ b/corral/cmd/cmd_fetch.pony
@@ -12,7 +12,7 @@ class CmdFetch
     //ctx.log.info("fetch: " + cmd.string())
 
     ctx.env.out.print("\nfetch:")
-    match BundleFile.load_bundle(ctx.env, ctx.log)
+    match BundleFile.load_bundle(ctx.env, ctx.path, ctx.log)
     | let bundle: Bundle =>
       fetch_bundle_deps(bundle, bundle)
     | let err: Error =>

--- a/corral/cmd/cmd_info.pony
+++ b/corral/cmd/cmd_info.pony
@@ -5,7 +5,10 @@ use "../util"
 
 primitive CmdInfo
   fun apply(ctx: Context, cmd: Command) =>
-    match BundleFile.load_bundle(ctx.env, ctx.path, ctx.log)
+    //ctx.log.info("info: " + cmd.string())
+    ctx.env.out.print("\ninfo: from dir " + ctx.directory)
+
+    match BundleFile.load_bundle(ctx.env, ctx.directory, ctx.log)
     | let bundle: Bundle =>
       ctx.env.out.print(
         "  information from " + Files.bundle_filename()

--- a/corral/cmd/cmd_info.pony
+++ b/corral/cmd/cmd_info.pony
@@ -5,8 +5,6 @@ use "../util"
 
 primitive CmdInfo
   fun apply(ctx: Context, cmd: Command) =>
-    //ctx.log.info("info: " + cmd.string())
-
     match BundleFile.load_bundle(ctx.env, ctx.path, ctx.log)
     | let bundle: Bundle =>
       ctx.env.out.print(

--- a/corral/cmd/cmd_info.pony
+++ b/corral/cmd/cmd_info.pony
@@ -7,9 +7,7 @@ primitive CmdInfo
   fun apply(ctx: Context, cmd: Command) =>
     //ctx.log.info("info: " + cmd.string())
 
-    ctx.env.out.print("\ninfo: from dir " + Path.cwd())
-
-    match BundleFile.load_bundle(ctx.env, ctx.log)
+    match BundleFile.load_bundle(ctx.env, ctx.path, ctx.log)
     | let bundle: Bundle =>
       ctx.env.out.print(
         "  information from " + Files.bundle_filename()

--- a/corral/cmd/cmd_init.pony
+++ b/corral/cmd/cmd_init.pony
@@ -6,11 +6,10 @@ use "../util"
 primitive CmdInit
   fun apply(ctx: Context, cmd: Command) =>
     //ctx.log.info("init: " + cmd.string())
-
-    ctx.env.out.print("\ninit: from dir " + Path.cwd())
+    ctx.env.out.print("\ninit: from dir " + ctx.path)
 
     // TODO: try to read first to convert/update existing file(s)
-    match BundleFile.create_bundle(ctx.env, ctx.log)
+    match BundleFile.create_bundle(ctx.env, ctx.path, ctx.log)
     | let bundle: Bundle =>
       try
         bundle.save()?

--- a/corral/cmd/cmd_init.pony
+++ b/corral/cmd/cmd_init.pony
@@ -5,7 +5,6 @@ use "../util"
 
 primitive CmdInit
   fun apply(ctx: Context, cmd: Command) =>
-    //ctx.log.info("init: " + cmd.string())
     ctx.env.out.print("\ninit: from dir " + ctx.path)
 
     // TODO: try to read first to convert/update existing file(s)

--- a/corral/cmd/cmd_init.pony
+++ b/corral/cmd/cmd_init.pony
@@ -5,10 +5,11 @@ use "../util"
 
 primitive CmdInit
   fun apply(ctx: Context, cmd: Command) =>
-    ctx.env.out.print("\ninit: from dir " + ctx.path)
+    //ctx.log.info("init: " + cmd.string())
+    ctx.env.out.print("\ninit: from dir " + ctx.directory)
 
     // TODO: try to read first to convert/update existing file(s)
-    match BundleFile.create_bundle(ctx.env, ctx.path, ctx.log)
+    match BundleFile.create_bundle(ctx.env, ctx.directory, ctx.log)
     | let bundle: Bundle =>
       try
         bundle.save()?

--- a/corral/cmd/cmd_list.pony
+++ b/corral/cmd/cmd_list.pony
@@ -5,17 +5,14 @@ use "../util"
 
 primitive CmdList
   fun apply(ctx: Context, cmd: Command) =>
-    //ctx.log.info("list: " + cmd.string())
+    ctx.env.out.print("\nlist: from dir " + ctx.path)
 
-    ctx.env.out.print("\nlist: from dir " + Path.cwd())
-
-    match BundleFile.load_bundle(ctx.env, ctx.log)
+    match BundleFile.load_bundle(ctx.env, ctx.path, ctx.log)
     | let bundle: Bundle =>
 
       ctx.env.out.print(
         "listing " + Files.bundle_filename() + " in " + bundle.name())
       for d in bundle.deps.values() do
-        //ctx.env.out.print("  " + d.data.json().string())
         ctx.env.out.print("  dep: " + d.name())
         ctx.env.out.print("    vcs: " + d.vcs())
         ctx.env.out.print("    ver: " + d.data.version)

--- a/corral/cmd/cmd_list.pony
+++ b/corral/cmd/cmd_list.pony
@@ -5,9 +5,10 @@ use "../util"
 
 primitive CmdList
   fun apply(ctx: Context, cmd: Command) =>
-    ctx.env.out.print("\nlist: from dir " + ctx.path)
+    //ctx.log.info("list: " + cmd.string())
+    ctx.env.out.print("\nlist: from dir " + ctx.directory)
 
-    match BundleFile.load_bundle(ctx.env, ctx.path, ctx.log)
+    match BundleFile.load_bundle(ctx.env, ctx.directory, ctx.log)
     | let bundle: Bundle =>
 
       ctx.env.out.print(

--- a/corral/cmd/cmd_remove.pony
+++ b/corral/cmd/cmd_remove.pony
@@ -4,8 +4,6 @@ use "../util"
 
 primitive CmdRemove
   fun apply(ctx: Context, cmd: Command) =>
-    //ctx.log.info("remove: " + cmd.string())
-
     ctx.env.out.print("\nremove: removing: TODO")
 
     match BundleFile.load_bundle(ctx.env, ctx.path, ctx.log)

--- a/corral/cmd/cmd_remove.pony
+++ b/corral/cmd/cmd_remove.pony
@@ -8,7 +8,7 @@ primitive CmdRemove
 
     ctx.env.out.print("\nremove: removing: TODO")
 
-    match BundleFile.load_bundle(ctx.env, ctx.log)
+    match BundleFile.load_bundle(ctx.env, ctx.path, ctx.log)
     | let bundle: Bundle =>
       try
         // TODO: lookup dep

--- a/corral/cmd/cmd_remove.pony
+++ b/corral/cmd/cmd_remove.pony
@@ -4,9 +4,10 @@ use "../util"
 
 primitive CmdRemove
   fun apply(ctx: Context, cmd: Command) =>
+    //ctx.log.info("remove: " + cmd.string())
     ctx.env.out.print("\nremove: removing: TODO")
 
-    match BundleFile.load_bundle(ctx.env, ctx.path, ctx.log)
+    match BundleFile.load_bundle(ctx.env, ctx.directory, ctx.log)
     | let bundle: Bundle =>
       try
         // TODO: lookup dep

--- a/corral/cmd/cmd_run.pony
+++ b/corral/cmd/cmd_run.pony
@@ -17,7 +17,7 @@ class CmdRun
 
     // Build a : separated path from bundle roots.
     let ponypath = recover val
-      match BundleFile.load_bundle(ctx.env, ctx.log)
+      match BundleFile.load_bundle(ctx.env, ctx.path, ctx.log)
       | let bundle: Bundle =>
         var ponypath' = recover trn String end
         let iter = bundle.bundle_roots().values()

--- a/corral/cmd/cmd_run.pony
+++ b/corral/cmd/cmd_run.pony
@@ -8,7 +8,6 @@ class CmdRun
 
   new create(ctx': Context, cmd: Command) =>
     ctx = ctx'
-    //ctx.log.info("run: " + cmd.string())
 
     let argss = cmd.arg("args").string_seq()
     let args = recover val Array[String].create() .> append(argss) end

--- a/corral/cmd/cmd_run.pony
+++ b/corral/cmd/cmd_run.pony
@@ -8,6 +8,7 @@ class CmdRun
 
   new create(ctx': Context, cmd: Command) =>
     ctx = ctx'
+    //ctx.log.info("run: " + cmd.string())
 
     let argss = cmd.arg("args").string_seq()
     let args = recover val Array[String].create() .> append(argss) end
@@ -16,7 +17,7 @@ class CmdRun
 
     // Build a : separated path from bundle roots.
     let ponypath = recover val
-      match BundleFile.load_bundle(ctx.env, ctx.path, ctx.log)
+      match BundleFile.load_bundle(ctx.env, ctx.directory, ctx.log)
       | let bundle: Bundle =>
         var ponypath' = recover trn String end
         let iter = bundle.bundle_roots().values()

--- a/corral/cmd/cmd_update.pony
+++ b/corral/cmd/cmd_update.pony
@@ -14,7 +14,7 @@ primitive CmdUpdate
 
     ctx.env.out.print("\nupdate:")
 
-    match recover BundleFile.load_bundle(ctx.env, ctx.path, ctx.log) end
+    match recover BundleFile.load_bundle(ctx.env, ctx.directory, ctx.log) end
     | let bundle: Bundle iso =>
       _Updater(ctx).update_bundle_deps(consume bundle)
     | let err: Error =>

--- a/corral/cmd/cmd_update.pony
+++ b/corral/cmd/cmd_update.pony
@@ -14,7 +14,7 @@ primitive CmdUpdate
 
     ctx.env.out.print("\nupdate:")
 
-    match recover BundleFile.load_bundle(ctx.env, ctx.log) end
+    match recover BundleFile.load_bundle(ctx.env, ctx.path, ctx.log) end
     | let bundle: Bundle iso =>
       _Updater(ctx).update_bundle_deps(consume bundle)
     | let err: Error =>

--- a/corral/cmd/context.pony
+++ b/corral/cmd/context.pony
@@ -6,22 +6,22 @@ class val Context
   Contains options and environment for all commands.
   """
   let env: Env
-  let path: String
   let log: Log
   let quiet: Bool
   let nothing: Bool
+  let directory: String
   let repo_cache: FilePath
   let corral_base: FilePath
 
   new val create(env': Env,
-    path': String,
+    directory': String,
     log': Log,
     quiet': Bool, nothing': Bool, repo_cache': String, corral_base': String) ?
   =>
     env = env'
-    path = path'
     log = log'
     quiet = quiet'
     nothing = nothing'
+    directory = directory'    
     repo_cache = FilePath(env.root as AmbientAuth, repo_cache')?
     corral_base = FilePath(env.root as AmbientAuth, corral_base')?

--- a/corral/cmd/context.pony
+++ b/corral/cmd/context.pony
@@ -6,6 +6,7 @@ class val Context
   Contains options and environment for all commands.
   """
   let env: Env
+  let path: String
   let log: Log
   let quiet: Bool
   let nothing: Bool
@@ -13,10 +14,12 @@ class val Context
   let corral_base: FilePath
 
   new val create(env': Env,
+    path': String,
     log': Log,
     quiet': Bool, nothing': Bool, repo_cache': String, corral_base': String) ?
   =>
     env = env'
+    path = path'
     log = log'
     quiet = quiet'
     nothing = nothing'

--- a/corral/main.pony
+++ b/corral/main.pony
@@ -39,12 +39,12 @@ actor Main
             "Show the version and exit")?
           CommandSpec.leaf(
             "init",
-            "Initializes the bundle.json and dep-lock.json files with"
+            "Initializes the corral.json and dep-lock.json files with"
               + " skeletal information.",
             [
               OptionSpec.string(
                 "path",
-                "Alternative bundle path."
+                "The path where corral.json and dep-lock.json will be created."
                 where short' = 'p',
                 default' = "")
             ]
@@ -56,7 +56,7 @@ actor Main
             [
               OptionSpec.string(
                 "path",
-                "Alternative bundle path."
+                "The path where both corral.json and dep-lock.json lives."
                 where short' = 'p',
                 default' = "")
             ])?
@@ -76,7 +76,7 @@ actor Main
                 default' = "")
               OptionSpec.string(
                 "path",
-                "Alternative bundle path."
+                "The path where both corral.json and dep-lock.json lives."
                 where short' = 'p',
                 default' = "")
             ],
@@ -89,7 +89,7 @@ actor Main
             [
               OptionSpec.string(
                 "path",
-                "Alternative bundle path."
+                "The path where both corral.json and dep-lock.json lives."
                 where short' = 'p',
                 default' = "")
             ])?
@@ -99,7 +99,7 @@ actor Main
             [
               OptionSpec.string(
                 "path",
-                "Alternative bundle path."
+                "The path where both corral.json and dep-lock.json lives."
                 where short' = 'p',
                 default' = "")
             ]
@@ -121,7 +121,7 @@ actor Main
                 default' = false)
               OptionSpec.string(
                 "path",
-                "Alternative bundle path."
+                "The path where both corral.json and dep-lock.json lives."
                 where short' = 'p',
                 default' = "")
             ])?
@@ -132,7 +132,7 @@ actor Main
             [
               OptionSpec.string(
                 "path",
-                "Alternative bundle path."
+                "The path where both corral.json and dep-lock.json lives."
                 where short' = 'p',
                 default' = "")
             ])?
@@ -142,7 +142,7 @@ actor Main
             [
               OptionSpec.string(
                 "path",
-                "Alternative bundle path."
+                "The path where both corral.json and dep-lock.json lives."
                 where short' = 'p',
                 default' = "")
             ])?

--- a/corral/main.pony
+++ b/corral/main.pony
@@ -39,12 +39,27 @@ actor Main
             "Show the version and exit")?
           CommandSpec.leaf(
             "init",
-            "Initializes the corral.json and dep-lock.json files with"
-              + " skeletal information.")?
+            "Initializes the bundle.json and dep-lock.json files with"
+              + " skeletal information.",
+            [
+              OptionSpec.string(
+                "path",
+                "Alternative bundle path."
+                where short' = 'p',
+                default' = "")
+            ]
+          )?
           CommandSpec.leaf(
             "info",
             "Prints all or specific information about the bundle from"
-              + " corral.json.")?
+              + " corral.json.",
+            [
+              OptionSpec.string(
+                "path",
+                "Alternative bundle path."
+                where short' = 'p',
+                default' = "")
+            ])?
           CommandSpec.leaf(
             "add",
             "Adds a remote VCS, local VCS or local direct dependency.",
@@ -59,16 +74,36 @@ actor Main
                 "Specific revision: tag, branch, commit"
                 where short' = 'r',
                 default' = "")
+              OptionSpec.string(
+                "path",
+                "Alternative bundle path."
+                where short' = 'p',
+                default' = "")
             ],
             [
               ArgSpec.string("locator", "Organization/repository name.")
             ])?
           CommandSpec.leaf(
             "remove",
-            "Removes one or more deps from the corral.")?
+            "Removes one or more deps from the corral.",
+            [
+              OptionSpec.string(
+                "path",
+                "Alternative bundle path."
+                where short' = 'p',
+                default' = "")
+            ])?
           CommandSpec.leaf(
             "list",
-            "Lists the deps and packages, including corral details.")?
+            "Lists the deps and packages, including corral details.",
+            [
+              OptionSpec.string(
+                "path",
+                "Alternative bundle path."
+                where short' = 'p',
+                default' = "")
+            ]
+          )?
           CommandSpec.leaf(
             "clean",
             "Cleans up repo cache and working corral. Default is to clean"
@@ -84,14 +119,33 @@ actor Main
                 "Clean repo cache only."
                 where short' = 'r',
                 default' = false)
+              OptionSpec.string(
+                "path",
+                "Alternative bundle path."
+                where short' = 'p',
+                default' = "")
             ])?
           CommandSpec.leaf(
             "update",
             "Updates one or more or all of the deps in the corral to their"
-              + " best revisions.")?
+              + " best revisions.",
+            [
+              OptionSpec.string(
+                "path",
+                "Alternative bundle path."
+                where short' = 'p',
+                default' = "")
+            ])?
           CommandSpec.leaf(
             "fetch",
-            "Fetches one or more or all of the deps into the corral.")?
+            "Fetches one or more or all of the deps into the corral.",
+            [
+              OptionSpec.string(
+                "path",
+                "Alternative bundle path."
+                where short' = 'p',
+                default' = "")
+            ])?
           CommandSpec.leaf(
             "run",
             "Runs a shell command inside an environment with the corral on"
@@ -125,13 +179,17 @@ actor Main
     let quiet = cmd.option("quiet").bool()
     let verbose = cmd.option("verbose").bool()
     let nothing = cmd.option("nothing").bool()
+    let path = match cmd.option("path").string()
+    | "" => Path.cwd()
+    | let path': String => Path.clean(path')
+    end
     let repo_cache = "./_repos"  // TODO: move default to user home and add flag
     let corral_base = "./_corral"
     //log.fine("Cmd: " + cmd.string())
 
     try
       let context =
-        recover Context(env, log, quiet, nothing, repo_cache, corral_base)? end
+        recover Context(env, path, log, quiet, nothing, repo_cache, corral_base)? end
 
       match cmd.fullname()
       | "corral/version" => env.out.print("corral " + Info.version())

--- a/corral/main.pony
+++ b/corral/main.pony
@@ -44,7 +44,7 @@ actor Main
             [
               OptionSpec.string(
                 "directory",
-                "The path where corral.json and dep-lock.json will be created."
+                "The directory where corral.json and dep-lock.json will be created."
                 where short' = 'p',
                 default' = "")
             ]
@@ -56,7 +56,7 @@ actor Main
             [
               OptionSpec.string(
                 "directory",
-                "The path where both corral.json and dep-lock.json live."
+                "The directory where both corral.json and dep-lock.json live."
                 where short' = 'p',
                 default' = "")
             ])?
@@ -76,7 +76,7 @@ actor Main
                 default' = "")
               OptionSpec.string(
                 "directory",
-                "The path where both corral.json and dep-lock.json live."
+                "The directory where both corral.json and dep-lock.json live."
                 where short' = 'p',
                 default' = "")
             ],
@@ -89,7 +89,7 @@ actor Main
             [
               OptionSpec.string(
                 "directory",
-                "The path where both corral.json and dep-lock.json live."
+                "The directory where both corral.json and dep-lock.json live."
                 where short' = 'p',
                 default' = "")
             ])?
@@ -99,7 +99,7 @@ actor Main
             [
               OptionSpec.string(
                 "directory",
-                "The path where both corral.json and dep-lock.json live."
+                "The directory where both corral.json and dep-lock.json live."
                 where short' = 'p',
                 default' = "")
             ]
@@ -121,7 +121,7 @@ actor Main
                 default' = false)
               OptionSpec.string(
                 "directory",
-                "The path where both corral.json and dep-lock.json live."
+                "The directory where both corral.json and dep-lock.json live."
                 where short' = 'p',
                 default' = "")
             ])?
@@ -132,7 +132,7 @@ actor Main
             [
               OptionSpec.string(
                 "directory",
-                "The path where both corral.json and dep-lock.json live."
+                "The directory where both corral.json and dep-lock.json live."
                 where short' = 'p',
                 default' = "")
             ])?
@@ -142,7 +142,7 @@ actor Main
             [
               OptionSpec.string(
                 "directory",
-                "The path where both corral.json and dep-lock.json live."
+                "The directory where both corral.json and dep-lock.json live."
                 where short' = 'p',
                 default' = "")
             ])?

--- a/corral/main.pony
+++ b/corral/main.pony
@@ -43,7 +43,7 @@ actor Main
               + " skeletal information.",
             [
               OptionSpec.string(
-                "path",
+                "directory",
                 "The path where corral.json and dep-lock.json will be created."
                 where short' = 'p',
                 default' = "")
@@ -55,8 +55,8 @@ actor Main
               + " corral.json.",
             [
               OptionSpec.string(
-                "path",
-                "The path where both corral.json and dep-lock.json lives."
+                "directory",
+                "The path where both corral.json and dep-lock.json live."
                 where short' = 'p',
                 default' = "")
             ])?
@@ -75,8 +75,8 @@ actor Main
                 where short' = 'r',
                 default' = "")
               OptionSpec.string(
-                "path",
-                "The path where both corral.json and dep-lock.json lives."
+                "directory",
+                "The path where both corral.json and dep-lock.json live."
                 where short' = 'p',
                 default' = "")
             ],
@@ -88,8 +88,8 @@ actor Main
             "Removes one or more deps from the corral.",
             [
               OptionSpec.string(
-                "path",
-                "The path where both corral.json and dep-lock.json lives."
+                "directory",
+                "The path where both corral.json and dep-lock.json live."
                 where short' = 'p',
                 default' = "")
             ])?
@@ -98,8 +98,8 @@ actor Main
             "Lists the deps and packages, including corral details.",
             [
               OptionSpec.string(
-                "path",
-                "The path where both corral.json and dep-lock.json lives."
+                "directory",
+                "The path where both corral.json and dep-lock.json live."
                 where short' = 'p',
                 default' = "")
             ]
@@ -120,8 +120,8 @@ actor Main
                 where short' = 'r',
                 default' = false)
               OptionSpec.string(
-                "path",
-                "The path where both corral.json and dep-lock.json lives."
+                "directory",
+                "The path where both corral.json and dep-lock.json live."
                 where short' = 'p',
                 default' = "")
             ])?
@@ -131,8 +131,8 @@ actor Main
               + " best revisions.",
             [
               OptionSpec.string(
-                "path",
-                "The path where both corral.json and dep-lock.json lives."
+                "directory",
+                "The path where both corral.json and dep-lock.json live."
                 where short' = 'p',
                 default' = "")
             ])?
@@ -141,8 +141,8 @@ actor Main
             "Fetches one or more or all of the deps into the corral.",
             [
               OptionSpec.string(
-                "path",
-                "The path where both corral.json and dep-lock.json lives."
+                "directory",
+                "The path where both corral.json and dep-lock.json live."
                 where short' = 'p',
                 default' = "")
             ])?
@@ -179,9 +179,9 @@ actor Main
     let quiet = cmd.option("quiet").bool()
     let verbose = cmd.option("verbose").bool()
     let nothing = cmd.option("nothing").bool()
-    let path = match cmd.option("path").string()
+    let directory = match cmd.option("directory").string()
     | "" => Path.cwd()
-    | let path': String => Path.clean(path')
+    | let dir': String => Path.clean(dir')
     end
     let repo_cache = "./_repos"  // TODO: move default to user home and add flag
     let corral_base = "./_corral"
@@ -189,7 +189,8 @@ actor Main
 
     try
       let context =
-        recover Context(env, path, log, quiet, nothing, repo_cache, corral_base)? end
+        recover Context(env, directory, log,
+          quiet, nothing,repo_cache, corral_base)? end
 
       match cmd.fullname()
       | "corral/version" => env.out.print("corral " + Info.version())

--- a/corral/test/main.pony
+++ b/corral/test/main.pony
@@ -11,14 +11,26 @@ actor Main is TestList
   fun tag tests(test: PonyTest) =>
     test(_TestGitParseTags)
     test(_TestCreateBundleInCustomPath)
+    test(_TestLoadBundleFromCustomPath)
 
 class iso _TestCreateBundleInCustomPath is UnitTest
-  fun name(): String => "bundle/create-in-custom-path"
+  fun name(): String => "bundle/create-bundle-in-custom-path"
 
   fun apply(h: TestHelper) ? =>
     let log = Log(LvlFine, h.env.err, LevelLogFormatter)
-    let expected = FilePath(h.env.root as AmbientAuth, "tmp")?
-    match BundleFile.create_bundle(h.env, "tmp", log)
+    let expected = FilePath(h.env.root as AmbientAuth, "custom/path")?
+    match BundleFile.create_bundle(h.env, "custom/path", log)
+    | let bundle: Bundle =>
+      h.assert_eq[String](expected.path, bundle.dir.path)
+    end
+
+class iso _TestLoadBundleFromCustomPath is UnitTest
+  fun name(): String => "bundle/load-bundle-from-custom-path"
+
+  fun apply(h: TestHelper) ? =>
+    let log = Log(LvlFine, h.env.err, LevelLogFormatter)
+    let expected = FilePath(h.env.root as AmbientAuth, "test")?
+    match BundleFile.load_bundle(h.env, "test", log)
     | let bundle: Bundle =>
       h.assert_eq[String](expected.path, bundle.dir.path)
     end

--- a/corral/test/main.pony
+++ b/corral/test/main.pony
@@ -1,5 +1,8 @@
 use "ponytest"
+use "files"
 use "../vcs"
+use "../bundle"
+use "../util"
 
 actor Main is TestList
   new create(env: Env) =>
@@ -7,6 +10,18 @@ actor Main is TestList
 
   fun tag tests(test: PonyTest) =>
     test(_TestGitParseTags)
+    test(_TestCreateBundleInCustomPath)
+
+class iso _TestCreateBundleInCustomPath is UnitTest
+  fun name(): String => "bundle/create-in-custom-path"
+
+  fun apply(h: TestHelper) ? =>
+    let log = Log(LvlFine, h.env.err, LevelLogFormatter)
+    let expected = FilePath(h.env.root as AmbientAuth, "tmp")?
+    match BundleFile.create_bundle(h.env, "tmp", log)
+    | let bundle: Bundle =>
+      h.assert_eq[String](expected.path, bundle.dir.path)
+    end
 
 class iso _TestGitParseTags is UnitTest
   fun name(): String => "git/parse-tags"


### PR DESCRIPTION
This change allows us to provide a directory for creating and loading both `corral.json` and `dep-lock.json` files. It affects most commands as they mostly need to load the file before doing their job. So, from now on, we can pass the `--path "path/to/the/bundle/dir/"` argument.

```bash
corral[master] % mkdir tmp
corral[master] % corral init --path tmp

init: from dir tmp
INFO: Created bundle in /Users/ordepdev/Work/corral/tmp
FINE: Going to write /Users/ordepdev/Work/corral/tmp/corral.json
INFO: Writing /Users/ordepdev/Work/corral/tmp/corral.json
FINE: Going to write /Users/ordepdev/Work/corral/tmp/lock.json
INFO: Writing /Users/ordepdev/Work/corral/tmp/lock.json
INFO: init: created: tmp
```

Solves https://github.com/ponylang/corral/issues/23.