### PR TITLE
Fix `corral run` should work if there is no corral.json

### DIFF
--- a/corral/cmd/cmd_run.pony
+++ b/corral/cmd/cmd_run.pony
@@ -27,9 +27,8 @@ class CmdRun
         end
         ponypath'
       | let err: Error =>
-        ctx.env.out.print("run: " + err.message)
-        ctx.env.exitcode(1)
-        return
+        ctx.env.out.print("run: continuing without a corral.json")
+        String
       end
     end
     ctx.log.info("run ponypath: " + ponypath)

--- a/corral/cmd/context.pony
+++ b/corral/cmd/context.pony
@@ -22,6 +22,6 @@ class val Context
     log = log'
     quiet = quiet'
     nothing = nothing'
-    directory = directory'    
-    repo_cache = FilePath(env.root as AmbientAuth, repo_cache')?
-    corral_base = FilePath(env.root as AmbientAuth, corral_base')?
+    directory = directory'
+    repo_cache = FilePath(env'.root as AmbientAuth, repo_cache')?
+    corral_base = FilePath(env'.root as AmbientAuth, corral_base')?

--- a/corral/main.pony
+++ b/corral/main.pony
@@ -7,9 +7,7 @@ primitive Info
   fun version(): String => Version()
 
 actor Main
-  let _env: Env
   new create(env: Env) =>
-    _env = env
     let log = Log(LvlFine, env.err, LevelLogFormatter)
 
     let cs = try


### PR DESCRIPTION
Run command no longer requires a corral.json bundle file. 
Removed extraneous envs.

Fixes #22
