### PR TITLE
Cleaned logs vs user output, implemented --nothing, fixed 'remove' command

### DIFF
--- a/corral/bundle/bundle.pony
+++ b/corral/bundle/bundle.pony
@@ -160,11 +160,10 @@ class Bundle
     deps(dd.locator) = Dep(this, dd, ld)
     modified = true
 
-  fun ref remove_dep(d: Dep) =>
-    try
-      deps.remove(d.data.locator)?
-      modified = true
-    end
+  fun ref remove_dep(locator: String) ? =>
+    log.fine("Removing " + locator + " from " + "|".join(deps.keys()))
+    deps.remove(locator)?
+    modified = true
 
   fun bundle_json(): JsonObject =>
     let jo: JsonObject = JsonObject

--- a/corral/cli.pony
+++ b/corral/cli.pony
@@ -1,7 +1,4 @@
 use "cli"
-use "files"
-use "util"
-use "cmd"
 
 primitive CLI
   fun parse(
@@ -28,6 +25,11 @@ primitive CLI
       "corral",
       "",
       [
+        OptionSpec.u64(
+          "debug",
+          "Configure debug output: 0=off, 1=err, 2=warn, 3=info, 4=fine."
+          where short'='g',
+          default' = 0)
         OptionSpec.bool(
           "quiet",
           "Quiet output."
@@ -82,14 +84,18 @@ primitive CLI
           ])?
         CommandSpec.leaf(
           "remove",
-          "Removes one or more deps from the corral.")?
+          "Removes one or more deps from the bundle.",
+          Array[OptionSpec](),
+          [
+            ArgSpec.string("locator", "Organization/repository name.")
+          ])?
         CommandSpec.leaf(
           "list",
           "Lists the deps and packages, including corral details.")?
         CommandSpec.leaf(
           "clean",
-          "Cleans up repo cache and working corral. Default is to clean"
-            + " only working corral.",
+          "Cleans repo cache and working corral. Default is to clean"
+            + " only the working corral.",
           [
             OptionSpec.bool(
               "all",

--- a/corral/cmd/cmd_add.pony
+++ b/corral/cmd/cmd_add.pony
@@ -5,8 +5,6 @@ use "../util"
 
 primitive CmdAdd
   fun apply(ctx: Context, cmd: Command) =>
-    //ctx.log.info("add: " + cmd.string())
-
     let dd = DepData(JsonObject)
     dd.locator = cmd.arg("locator").string()
     dd.version = cmd.option("version").string()
@@ -15,23 +13,28 @@ primitive CmdAdd
     ld.locator = dd.locator
     ld.revision = cmd.option("revision").string()
 
-    ctx.env.out.print(
-      "\nadd: adding: " + dd.locator.string() + " "
+    ctx.uout.info(
+      "add: adding: " + dd.locator.string() + " "
         + dd.version.string() + " " + ld.revision.string())
 
     match BundleFile.load_bundle(ctx.bundle_dir, ctx.log)
     | let bundle: Bundle =>
       try
         bundle.add_dep(dd, ld)
-        bundle.save()?
-        ctx.env.out.print(
-          "  added: " + dd.json().string() + " " + ld.json().string())
-        //bundle.fetch() // TODO: maybe just fetch this one new dep
+        if not ctx.nothing then
+          bundle.save()?
+          ctx.uout.info(
+            "add: added dep: " + dd.json().string() + " " + ld.json().string())
+          //bundle.fetch() // TODO: maybe just fetch this one new dep
         else
-          ctx.env.out.print("  could not update " + bundle.name())
-          ctx.env.exitcode(1)
+          ctx.uout.info(
+            "add: would have added dep: " + dd.json().string() + " " + ld.json().string())
         end
+      else
+        ctx.uout.warn("add: could not update " + bundle.name())
+        ctx.env.exitcode(1)
+      end
     | let err: Error =>
-      ctx.env.out.print(err.message)
+      ctx.uout.err(err.message)
       ctx.env.exitcode(1)
     end

--- a/corral/cmd/cmd_info.pony
+++ b/corral/cmd/cmd_info.pony
@@ -5,16 +5,15 @@ use "../util"
 
 primitive CmdInfo
   fun apply(ctx: Context, cmd: Command) =>
-    //ctx.log.info("info: " + cmd.string())
-    ctx.env.out.print("\ninfo: from dir " + ctx.bundle_dir.path)
+    ctx.uout.info("info: from dir " + ctx.bundle_dir.path)
 
     match BundleFile.load_bundle(ctx.bundle_dir, ctx.log)
     | let bundle: Bundle =>
-      ctx.env.out.print(
-        "  information from " + Files.bundle_filename()
+      ctx.uout.info(
+        "info: from " + Files.bundle_filename()
           + " in " + bundle.name())
-      ctx.env.out.print("  info: " + bundle.info.json().string())
+      ctx.env.out.print("info: " + bundle.info.json().string())
     | let err: Error =>
-      ctx.env.out.print(err.message)
+      ctx.uout.err(err.message)
       ctx.env.exitcode(1)
     end

--- a/corral/cmd/cmd_init.pony
+++ b/corral/cmd/cmd_init.pony
@@ -5,20 +5,23 @@ use "../util"
 
 primitive CmdInit
   fun apply(ctx: Context, cmd: Command) =>
-    //ctx.log.info("init: " + cmd.string())
-    ctx.env.out.print("\ninit: from dir " + ctx.bundle_dir.path)
+    ctx.uout.info("init: from dir " + ctx.bundle_dir.path)
 
     // TODO: try to read first to convert/update existing file(s)
     match BundleFile.create_bundle(ctx.bundle_dir, ctx.log)
     | let bundle: Bundle =>
       try
-        bundle.save()?
-        ctx.log.info("init: created: " + bundle.name())
+        if not ctx.nothing then
+          bundle.save()?
+          ctx.uout.info("init: created: " + bundle.name())
+        else
+          ctx.uout.info("init: would have created: " + bundle.name())
+        end
       else
-        ctx.env.out.print("init: could not create " + bundle.name())
+        ctx.uout.err("init: could not create: " + bundle.name())
         ctx.env.exitcode(1)
       end
     | let err: Error =>
-      ctx.env.out.print(err.message)
+      ctx.uout.err(err.message)
       ctx.env.exitcode(1)
     end

--- a/corral/cmd/cmd_list.pony
+++ b/corral/cmd/cmd_list.pony
@@ -5,27 +5,26 @@ use "../util"
 
 primitive CmdList
   fun apply(ctx: Context, cmd: Command) =>
-    //ctx.log.info("list: " + cmd.string())
-    ctx.env.out.print("\nlist: from dir " + ctx.bundle_dir.path)
+    ctx.uout.info("list: from dir " + ctx.bundle_dir.path)
 
     match BundleFile.load_bundle(ctx.bundle_dir, ctx.log)
     | let bundle: Bundle =>
 
-      ctx.env.out.print(
-        "listing " + Files.bundle_filename() + " in " + bundle.name())
+      ctx.uout.info(
+        "list: listing " + Files.bundle_filename() + " in " + bundle.name())
       for d in bundle.deps.values() do
-        ctx.env.out.print("  dep: " + d.name())
-        ctx.env.out.print("    vcs: " + d.vcs())
-        ctx.env.out.print("    ver: " + d.data.version)
-        ctx.env.out.print("    rev: " + d.lock.revision)
+        ctx.uout.info("  dep: " + d.name())
+        ctx.uout.info("    vcs: " + d.vcs())
+        ctx.uout.info("    ver: " + d.data.version)
+        ctx.uout.info("    rev: " + d.lock.revision)
       end
 
-      ctx.env.out.print("")
+      ctx.uout.info("")
       for br in bundle.bundle_roots().values() do
-        ctx.env.out.print("  dep_root: " + br)
+        ctx.uout.info("  dep_root: " + br)
       end
 
     | let err: Error =>
-      ctx.env.out.print("list: " + err.message)
+      ctx.uout.err("list: " + err.message)
       ctx.env.exitcode(1)
     end

--- a/corral/cmd/cmd_remove.pony
+++ b/corral/cmd/cmd_remove.pony
@@ -1,24 +1,34 @@
 use "cli"
+use "json"
 use "../bundle"
 use "../util"
 
 primitive CmdRemove
   fun apply(ctx: Context, cmd: Command) =>
-    //ctx.log.info("remove: " + cmd.string())
-    ctx.env.out.print("\nremove: removing: TODO")
+    let locator = cmd.arg("locator").string()
+    ctx.uout.info("remove: removing: " + locator)
 
     match BundleFile.load_bundle(ctx.bundle_dir, ctx.log)
     | let bundle: Bundle =>
       try
-        // TODO: lookup dep
-        //bundle.remove_dep(dep)
-        bundle.save()?
-        //ctx.env.out.print("remove: removed " + cmd.string())
+        bundle.remove_dep(locator)?
       else
-        ctx.env.out.print("remove: could not update " + bundle.name())
+        ctx.uout.err("remove: dep not found in: " + bundle.name())
+        ctx.env.exitcode(1)
+        return
+      end
+      try
+        if not ctx.nothing then
+          bundle.save()?
+          ctx.uout.info("remove: removed: " + locator)
+        else
+          ctx.uout.info("remove: would have removed: " + locator)
+        end
+      else
+        ctx.uout.err("remove: could not update: " + bundle.name())
         ctx.env.exitcode(1)
       end
     | let err: Error =>
-      ctx.env.out.print(err.message)
+      ctx.uout.err(err.message)
       ctx.env.exitcode(1)
     end

--- a/corral/cmd/cmd_run.pony
+++ b/corral/cmd/cmd_run.pony
@@ -1,17 +1,14 @@
 use "cli"
 use "process"
 use "../bundle"
-use "../util" // Log
+use "../util"
 
 class CmdRun
-
   new create(ctx: Context, cmd: Command) =>
-    //ctx.log.info("run: " + cmd.string())
-
     let argss = cmd.arg("args").string_seq()
     let args = recover val Array[String].create() .> append(argss) end
 
-    ctx.env.out.print("\nrun: ") // + args.string())
+    ctx.uout.info("run: " + " ".join(args.values()))
 
     // Build a : separated path from bundle roots.
     let ponypath = recover val
@@ -25,7 +22,7 @@ class CmdRun
         end
         ponypath'
       | let err: Error =>
-        ctx.env.out.print("run: continuing without a corral.json")
+        ctx.uout.warn("run: continuing without a corral.json")
         String
       end
     end
@@ -39,9 +36,11 @@ class CmdRun
           ctx.env.vars
         end
       let a = Action(prog, recover args.slice(1) end, vars)
-      Runner.run(a, {(result: ActionResult) => result.print_to(ctx.env.out) })
+      if not ctx.nothing then
+        Runner.run(a, {(result: ActionResult) => result.print_to(ctx.env.out) })
+      end
     else
-      ctx.env.out.print("run: " + "couldn't run program: " + cmd.string())
+      ctx.uout.err("run: " + "couldn't run program: " + cmd.string())
       ctx.env.exitcode(1)
       return
     end

--- a/corral/cmd/cmd_version.pony
+++ b/corral/cmd/cmd_version.pony
@@ -1,6 +1,0 @@
-use "cli"
-use ".."
-
-primitive CmdVersion
-  fun apply(ctx: Context, cmd: Command) =>
-    ctx.env.out.print("\nCorral version: " + Version())

--- a/corral/cmd/context.pony
+++ b/corral/cmd/context.pony
@@ -7,18 +7,18 @@ class val Context
   """
   let env: Env
   let log: Log
-  let quiet: Bool
+  let uout: Log
   let nothing: Bool
   let bundle_dir: FilePath
   let repo_cache: FilePath
 
-  new val create(env': Env, log': Log,
-    quiet': Bool, nothing': Bool,
+  new val create(env': Env, log': Log, uout': Log,
+    nothing': Bool,
     bundle_dir': FilePath, repo_cache': FilePath)
   =>
     env = env'
     log = log'
-    quiet = quiet'
+    uout = uout'
     nothing = nothing'
     bundle_dir = bundle_dir'
     repo_cache = repo_cache'

--- a/corral/test/integration/test_version.pony
+++ b/corral/test/integration/test_version.pony
@@ -11,6 +11,6 @@ class TestVersion is UnitTest
 class CheckVersion is Checker
   fun tag apply(h: TestHelper, ar: ActionResult) =>
     h.assert_eq[I32](0, ar.exit_code)
-    h.assert_true(ar.stdout.at("corral "))
-    h.assert_true(ar.stdout.at(Info.version(), 7))
+    h.assert_true(ar.stdout.at("version: "))
+    h.assert_true(ar.stdout.at(Info.version(), 9))
     h.complete(ar.exit_code == 0)

--- a/corral/util/log.pony
+++ b/corral/util/log.pony
@@ -1,37 +1,51 @@
 type LogLevel is
-  ( LvlFine
-  | LvlInfo
-  | LvlWarn
+  ( LvlNone
   | LvlErrr
-  | LvlNone )
+  | LvlWarn
+  | LvlInfo
+  | LvlFine
+  )
 
-primitive LvlFine
+primitive LvlNone
   fun apply(): U32 => 0
-  fun string(): String => "FINE"
+  fun string(): String => "-"
 
-primitive LvlInfo
+primitive LvlErrr
   fun apply(): U32 => 1
-  fun string(): String => "INFO"
+  fun string(): String => "ERRR"
 
 primitive LvlWarn
   fun apply(): U32 => 2
   fun string(): String => "WARN"
 
-primitive LvlErrr
+primitive LvlInfo
   fun apply(): U32 => 3
-  fun string(): String => "ERRR"
+  fun string(): String => "INFO"
 
-primitive LvlNone
+primitive LvlFine
   fun apply(): U32 => 4
-  fun string(): String => "-"
+  fun string(): String => "FINE"
+
+primitive Level
+  fun apply(lvl: U64): LogLevel =>
+    match lvl
+    | 0 => LvlNone
+    | 1 => LvlErrr
+    | 2 => LvlWarn
+    | 3 => LvlInfo
+    | 4 => LvlFine
+    else
+      LvlFine
+    end
 
 class val Log
   """
   A wrapped output stream for use in logging. It supports logging at four
-  levels: err, warn, info and fine.
+  levels: err, warn, info and fine. Plus setting None to turn off output.
   Log level is checked behind the call for convenience at the tradeoff of
-  performance. The formatter can also be selected to customize the log line
-  content and format.
+  performance.
+  The formatter can also be selected to customize the log line content and
+  format.
   """
   let _level: LogLevel
   let _out: OutStream
@@ -47,7 +61,7 @@ class val Log
     _formatter = formatter
 
   fun log(level: LogLevel, msg: String, loc: SourceLoc = __loc) =>
-    if (level() >= _level()) then
+    if (level() <= _level()) then
       _out.print(_formatter(level, msg, loc))
     end
 


### PR DESCRIPTION
- Cleaned logs vs user output:
  - Debug log level is set with --debug
  - User output level is set with --quiet and --verbose
- Implemented --nothing everywhere.
- Added missing remove command implementation.

Fixes:
ponylang#61 and ponylang#24: Logs vs user output.
ponylang#27: --nothing/-n implemented