### PR TITLE
Add macOS releases via Homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,23 @@ jobs:
       - name: Build and push
         run: bash .ci-scripts/release/build-docker-images-on-release.bash
 
+  homebrew:
+    name: Bump Homebrew formula
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@eb843fa04b91b8bc5d4953899e3fff15c95f347c
+        if: "!contains(github.ref, '-')" # skip prereleases
+        with:
+          formula-name: corral
+        env:
+          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_RELEASE_TOKEN }
+
   trigger-release-announcement:
     name: Trigger release announcement
     runs-on: ubuntu-latest
     container:
       image: ponylang/shared-docker-ci-release:20191107
-    needs: [create-and-upload-a-release, build-release-docker-images]
+    needs: [create-and-upload-a-release, build-release-docker-images, homebrew]
     steps:
       - uses: actions/checkout@v1
       - name: Trigger release announcement

--- a/README.md
+++ b/README.md
@@ -36,12 +36,22 @@ Check out [Pony Package Dependency Management](doc/package_dependency_management
 
 ## Installation
 
-### Ponyup!
+### Linux
+
+Use [ponyup](https://github.com/ponylang/ponyup) to install corral.
 
 The following command will download the latest release of `corral` and install it to `~/.pony/ponyup/bin` by default. This requires `ponyup`, our toolchain multiplexer, to be installed. If you don't have it installed, please follow the [instructions](https://github.com/ponylang/ponyup#installing-ponyup).
 
 ```bash
 ponyup update corral release
+```
+
+### macOS
+
+Use [homebrew](https://brew.sh) to install corral.
+
+```bash
+brew install corral
 ```
 
 ## Building From Source

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -24,7 +24,7 @@ git push origin release-0.3.1
 
 ## If something goes wrong
 
-The release process can be restarted at various points in it's lifecycle by pushing specially crafted tags.
+The release process can be restarted at various points in its life-cycle by pushing specially crafted tags.
 
 ## Start a release
 
@@ -33,6 +33,18 @@ As documented above, a release is started by pushing a tag of the form `release-
 ## Build artifacts
 
 The release process can be manually restarted from here by pushing a tag of the form `x.y.z`. The pushed tag must be on the commit to build the release artifacts from. During the normal process, that commit is the same as the one that `release-x.y.z`.
+
+### Updating Homebrew
+
+Fork the [homebrew-core repo](https://github.com/Homebrew/homebrew-core) and then clone it locally. You are going to be editing "Formula/corral.rb". If you already have a local copy of homebrew-core, make sure you sync up with the main Homebrew repo otherwise you might change an older version of the formula and end up with merge conflicts.
+
+Make sure you do your changes on a branch:
+
+* git checkout -b corral-0.3.1
+
+HomeBrew has [directions](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md#submit-a-123-version-upgrade-for-the-foo-formula) on what specifically you need to update in a formula to account for an upgrade. If you are on macOS and are unsure of how to get the SHA of the release .tar.gz, download the release file (make sure it does unzip it) and run `shasum -a 256 corral-0.3.1.tar.gz`. If you are on macOS, its quite possible it will try to unzip the file on your. In Safari, right clicking and selecting "Download Linked File" will get your the complete .tar.gz.
+
+After updating the corral formula, push to your fork and open a PR against homebrew-core. According to the homebrew team, their preferred naming for such PRs is `corral 0.3.1` that is, the name of the formula being updated followed by the new version number.
 
 ## Announce release
 


### PR DESCRIPTION
This shouldn't be merged until corral is added to homebrew.
There is currently a PR open to add it:

https://github.com/Homebrew/homebrew-core/pull/48075