### PR TITLE
Pass exit codes from Runners to early exit corral with same code

### DIFF
--- a/corral/cmd/cmd_run.pony
+++ b/corral/cmd/cmd_run.pony
@@ -44,7 +44,12 @@ class CmdRun is CmdType
         end
       let a = Action(prog, recover args.slice(1) end, vars)
       if not ctx.nothing then
-        Runner.run(a, {(result: ActionResult) => result.print_to(ctx.env.out) })
+        Runner.run(a, {(result: ActionResult) => 
+          result.print_to(ctx.env.out)
+          if result.exit_code != 0 then
+            ctx.env.exitcode(result.exit_code)
+          end
+        })
       end
     else
       ctx.uout.err("run: " + "couldn't run program: " + " ".join(args.values()))

--- a/corral/vcs/git.pony
+++ b/corral/vcs/git.pony
@@ -54,12 +54,24 @@ class val GitSyncRepo is RepoOperation
     let action = Action(git.prog,
       recover ["clone"; "--no-checkout"; remote_uri; repo.local.path] end,
       git.env.vars)
-    Runner.run(action, {(ar: ActionResult)(self=this) => self._log_err(ar); self._done(ar, repo)} iso)
+    Runner.run(action, {(ar: ActionResult)(self=this) => 
+      self._log_err(ar)
+      if ar.exit_code != 0 then
+        git.env.exitcode(ar.exit_code)
+      end
+      self._done(ar, repo)
+    } iso)
 
   fun val _fetch(repo: Repo) =>
     let action = Action(git.prog,
       recover ["-C"; repo.local.path; "fetch"; "--tags"] end, git.env.vars)
-    Runner.run(action, {(ar: ActionResult)(self=this) => self._log_err(ar); self._done(ar, repo)} iso)
+    Runner.run(action, {(ar: ActionResult)(self=this) => 
+      self._log_err(ar)
+      if ar.exit_code != 0 then
+        git.env.exitcode(ar.exit_code)
+      end
+      self._done(ar, repo)
+    } iso)
 
   fun val _done(ar: ActionResult, repo: Repo) =>
     //ar.print_to(git.env.err)
@@ -85,8 +97,13 @@ class val GitQueryTags is RepoOperation
     let action = Action(git.prog,
       recover ["-C"; repo.local.path; "show-ref"] end,
       git.env.vars)
-    Runner.run(action,
-      {(ar: ActionResult)(self=this) => self._log_err(ar); self._parse_tags(ar, repo)} iso)
+    Runner.run(action, {(ar: ActionResult)(self=this) => 
+      self._log_err(ar)
+      if ar.exit_code != 0 then
+        git.env.exitcode(ar.exit_code)
+      end
+      self._parse_tags(ar, repo)
+    } iso)
 
   fun val _parse_tags(ar: ActionResult, repo: Repo) =>
     //ar.print_to(git.env.err)
@@ -133,8 +150,13 @@ class val GitCheckoutRepo is RepoOperation
     let action = Action(git.prog,
       recover ["-C"; repo.local.path; "reset"; "--mixed"; rev ] end,
       git.env.vars)
-    Runner.run(action,
-      {(ar: ActionResult)(self=this) => self._log_err(ar); self._checkout_to_workspace(repo)} iso)
+    Runner.run(action, {(ar: ActionResult)(self=this) =>
+      self._log_err(ar)
+      if ar.exit_code != 0 then
+        git.env.exitcode(ar.exit_code)
+      end
+      self._checkout_to_workspace(repo)
+    } iso)
 
   fun val _checkout_to_workspace(repo: Repo) =>
     // Maybe: --recurse-submodules --quiet --verbose
@@ -147,8 +169,13 @@ class val GitCheckoutRepo is RepoOperation
         "--prefix=" + repo.workspace.path + "/"
       ] end,
       git.env.vars)
-    Runner.run(action,
-      {(ar: ActionResult)(self=this) => self._log_err(ar); self._done(ar, repo)} iso)
+    Runner.run(action, {(ar: ActionResult)(self=this) => 
+      self._log_err(ar)
+      if ar.exit_code != 0 then
+        git.env.exitcode(ar.exit_code)
+      end
+      self._done(ar, repo)
+    } iso)
 
   fun val _done(ar: ActionResult, repo: Repo) =>
     // TODO: check ar.exit_code == 0 before proceeding


### PR DESCRIPTION

If a Runner critical to the correct result of corral fails then it is
better to have all of corral exit immediately (passing through the exit
code). For example, if a git pull fails to execute, we could continue to
compile the project with the wrong code ending with an incorrect result.
Another common example when ponyc compile fails and you are using corral
in a larger make system, you want the make system to know the command
failed.