### PR TITLE
Update to reflect ponyc --version output change

### DIFF
--- a/corral/test/integration/test_run.pony
+++ b/corral/test/integration/test_run.pony
@@ -16,7 +16,7 @@ class TestRun is UnitTest
       ] end,
       {(h: TestHelper, ar: ActionResult) =>
         h.assert_eq[I32](0, ar.exit_code)
-        h.assert_true(ar.stdout.contains("compiled with: "))
+        h.assert_true(ar.stdout.contains("Compiled with: "))
         h.complete(ar.exit_code == 0)
       })
 
@@ -33,6 +33,6 @@ class TestRunWithoutBundle is UnitTest
       ] end,
       {(h: TestHelper, ar: ActionResult) =>
         h.assert_eq[I32](0, ar.exit_code)
-        h.assert_true(ar.stdout.contains("compiled with: "))
+        h.assert_true(ar.stdout.contains("Compiled with: "))
         h.complete(ar.exit_code == 0)
       })


### PR DESCRIPTION
As part of the recent cmake upgrade, the error where `Compiled with:` wasn't capitalized was fixed. It is now capitalized like `Defaults:` is.
Two tests started failing because of that as they are case-sensitive.