### PR TITLE
Update to handle new `ProcessError` types

### DIFF
--- a/corral/test/util.pony
+++ b/corral/test/util.pony
@@ -47,10 +47,8 @@ class val DataClone
     _dir = _root.join(subdir)?
 
     Copy.tree(src_root, _root, subdir)?
-    //h.env.err.print("cloned _root: " + _root.path)
 
   fun cleanup(h: TestHelper) =>
-    //h.env.err.print("cleaning up _root: " + _root.path)
     _root.remove()
 
   fun dir(): String => _dir.path

--- a/corral/util/action.pony
+++ b/corral/util/action.pony
@@ -144,17 +144,7 @@ class _Collector is ProcessNotify
     _stderr.append(consume data)
 
   fun ref failed(process: ProcessMonitor ref, err: ProcessError) =>
-    let errmsg = match err
-      | ExecveError => "ProcessError: ExecveError"
-      | PipeError => "ProcessError: PipeError"
-      | ForkError => "ProcessError: ForkError"
-      | WaitpidError => "ProcessError: WaitpidError"
-      | WriteError => "ProcessError: WriteError"
-      | KillError => "ProcessError: KillError"
-      | Unsupported => "ProcessError: Unsupported"
-      | CapError =>  "ProcessError: CapError"
-      end
-    let cr = ActionResult.fail(errmsg)
+    let cr = ActionResult.fail(err.string())
     _result(cr)
 
   fun ref dispose(process: ProcessMonitor ref, child_exit_code: I32) =>


### PR DESCRIPTION
The `ProcessError` types from the stdlib `process` package now store their own error messages.

Fixes #88.