### PR TITLE
Install ponyc on macOS via ponyup

### DIFF
--- a/.ci-scripts/macOS-install-pony-tools.bash
+++ b/.ci-scripts/macOS-install-pony-tools.bash
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh | sh
+
+export PATH="$HOME/.local/share/ponyup/bin/:$PATH"
+
+ponyup update ponyc release

--- a/.ci-scripts/release/x86-64-apple-darwin-nightly.bash
+++ b/.ci-scripts/release/x86-64-apple-darwin-nightly.bash
@@ -55,6 +55,9 @@ fi
 # allow above so we can display nice error messages for expected unset variables
 set -o nounset
 
+# add ponyup installed ponyc to our PATH
+export PATH="$HOME/.local/share/ponyup/bin/:$PATH"
+
 TODAY=$(date +%Y%m%d)
 
 # Compiler target parameters

--- a/.ci-scripts/release/x86-64-apple-darwin-release.bash
+++ b/.ci-scripts/release/x86-64-apple-darwin-release.bash
@@ -55,6 +55,9 @@ fi
 # allow above so we can display nice error messages for expected unset variables
 set -o nounset
 
+# add ponyup installed ponyc to our PATH
+export PATH="$HOME/.local/share/ponyup/bin/:$PATH"
+
 # Compiler target parameters
 ARCH=x86-64
 

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
-      - name: brew install ponyc
-        run: brew install ponyc
+      - name: install ponyc
+        run: bash macOS-install-pony-tools.bash
       - name: brew install dependencies
         run: brew install coreutils python
       - name: pip install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
-      - name: brew install ponyc
-        run: brew install ponyc
+      - name: install ponyc
+        run: bash macOS-install-pony-tools.bash
       - name: brew install dependencies
         run: brew install coreutils python
       - name: pip install dependencies


### PR DESCRIPTION
Our nightly builds are failing (and our release builds will fail) because
homebrew doesn't have the latest ponyc compiler. As ponyup is now our
officially supported macOS ponyc installation tool, we need to use it
as part of our nightly and release builds to prevent breakage going
forward.