### PR TITLE
Allow use of lldb with corral

### DIFF
--- a/corral/cli.pony
+++ b/corral/cli.pony
@@ -123,5 +123,12 @@ primitive CLI
           [
             ArgSpec.string_seq("args", "Arguments to run.")
           ])?
+        CommandSpec.leaf(
+          "exec",
+          "For executing shell commands which require user interaction",
+          Array[OptionSpec](),
+          [
+            ArgSpec.string_seq("args", "Arguments to run.")
+          ])?
       ])?
       .> add_help()?

--- a/corral/main.pony
+++ b/corral/main.pony
@@ -37,7 +37,8 @@ actor Main
       | "corral/init" => CmdInit(cmd)
       | "corral/list" => CmdList(cmd)
       | "corral/remove" => CmdRemove(cmd)
-      | "corral/run" => CmdRun(cmd)
+      | "corral/run" => CmdRun(cmd, false)
+      | "corral/exec" => CmdRun(cmd, true)
       | "corral/update" => CmdUpdate(cmd)
       | "corral/version" => CmdVersion(cmd)
       else


### PR DESCRIPTION
The "run" command captures all input and output of the command being
run, making it difficult to be used with dynamic tools such as lldb when
debugging ponyc changes. Instead of altering how run works, I added an
"exec" command which just execve's the process and gives everything
over to the command being executed. This has allowed full access for
working with lldb.