### PR TITLE
Remove extraneous CR in outputs on Windows

### DIFF
--- a/corral/util/action.pony
+++ b/corral/util/action.pony
@@ -99,8 +99,19 @@ class val ActionResult
 
   fun val print_to(out: OutStream) =>
     out.print("  exit: " + exit_status.string())
-    out.print("  out: " + stdout)
-    out.print("  err: " + stderr)
+
+    ifdef windows then
+      let stdout' = stdout.clone()
+      stdout'.replace("\r", "")
+      out.print("  out:\n" + (consume stdout'))
+
+      let stderr' = stderr.clone()
+      stderr'.replace("\r", "")
+      out.print("  err:\n" + (consume stderr'))
+    else
+      out.print("  out: " + stdout)
+      out.print("  err: " + stderr)
+    end
 
   fun successful(): Bool =>
     match exit_status


### PR DESCRIPTION
Printing stdout as a string will replace `"\n"` with `"\r\n"`.  Since the contents of stdout already have `"\r\n"`, the eventual output on Windows will have `"\r\r\n"`.  This will cause the output to have extra lines in PowerShell.

This PR removes CRs (`"\r"`) from the stdout and stderr strings to avoid this.

This is a minor cosmetic change.