### PR TITLE
Add VCSBuilder class

### DIFF
--- a/corral/cmd/cmd_add.pony
+++ b/corral/cmd/cmd_add.pony
@@ -2,6 +2,7 @@ use "cli"
 use "json"
 use "../bundle"
 use "../util"
+use "../vcs"
 
 class CmdAdd is CmdType
   let locator: String
@@ -13,7 +14,7 @@ class CmdAdd is CmdType
     version = cmd.option("version").string()
     revision = cmd.option("revision").string()
 
-  fun apply(ctx: Context, project: Project) =>
+  fun apply(ctx: Context, project: Project, vcs_builder: VCSBuilder) =>
     ctx.uout.info(
       "add: adding: " + locator + " " + version + " " + revision)
 

--- a/corral/cmd/cmd_clean.pony
+++ b/corral/cmd/cmd_clean.pony
@@ -2,6 +2,7 @@ use "cli"
 use "files"
 use "../bundle"
 use "../util"
+use "../vcs"
 
 class CmdClean is CmdType
   let clean_repos: Bool
@@ -18,7 +19,7 @@ class CmdClean is CmdType
     // clean_corral
     true
 
-  fun apply(ctx: Context, project: Project) =>
+  fun apply(ctx: Context, project: Project, vcs_builder: VCSBuilder) =>
     ctx.uout.info(
       "clean: corral:" + clean_corral.string() +
       " repos:" + clean_repos.string())

--- a/corral/cmd/cmd_info.pony
+++ b/corral/cmd/cmd_info.pony
@@ -2,12 +2,13 @@ use "cli"
 use "files"
 use "../bundle"
 use "../util"
+use "../vcs"
 
 class CmdInfo is CmdType
 
   new create(cmd: Command) => None
 
-  fun apply(ctx: Context, project: Project) =>
+  fun apply(ctx: Context, project: Project, vcs_builder: VCSBuilder) =>
     ctx.uout.info("info: from " + project.dir.path)
 
     match project.load_bundle()

--- a/corral/cmd/cmd_init.pony
+++ b/corral/cmd/cmd_init.pony
@@ -2,6 +2,7 @@ use "cli"
 use "files"
 use "../bundle"
 use "../util"
+use "../vcs"
 
 class CmdInit is CmdType
 
@@ -10,7 +11,7 @@ class CmdInit is CmdType
   fun requires_bundle(): Bool => false
   fun requires_no_bundle(): Bool => true
 
-  fun apply(ctx: Context, project: Project) =>
+  fun apply(ctx: Context, project: Project, vcs_builder: VCSBuilder) =>
     ctx.uout.info("init: in " + project.dir.path)
 
     // TODO: try to read first to convert/update existing file(s)

--- a/corral/cmd/cmd_list.pony
+++ b/corral/cmd/cmd_list.pony
@@ -2,12 +2,13 @@ use "cli"
 use "files"
 use "../bundle"
 use "../util"
+use "../vcs"
 
 class CmdList is CmdType
 
   new create(cmd: Command) => None
 
-  fun apply(ctx: Context, project: Project) =>
+  fun apply(ctx: Context, project: Project, vcs_builder: VCSBuilder) =>
     ctx.uout.info("list: from " + project.dir.path)
 
     match project.load_bundle()

--- a/corral/cmd/cmd_remove.pony
+++ b/corral/cmd/cmd_remove.pony
@@ -2,6 +2,7 @@ use "cli"
 use "json"
 use "../bundle"
 use "../util"
+use "../vcs"
 
 class CmdRemove is CmdType
   let locator: String
@@ -9,7 +10,7 @@ class CmdRemove is CmdType
   new create(cmd: Command) =>
     locator = cmd.arg("locator").string()
 
-  fun apply(ctx: Context, project: Project) =>
+  fun apply(ctx: Context, project: Project, vcs_builder: VCSBuilder) =>
     ctx.uout.info("remove: removing: " + locator)
 
     match project.load_bundle()

--- a/corral/cmd/cmd_run.pony
+++ b/corral/cmd/cmd_run.pony
@@ -3,6 +3,7 @@ use "files"
 use "process"
 use "../bundle"
 use "../util"
+use "../vcs"
 
 class CmdRun is CmdType
   let args: Array[String] val
@@ -13,7 +14,7 @@ class CmdRun is CmdType
 
   fun requires_bundle(): Bool => false
 
-  fun apply(ctx: Context, project: Project) =>
+  fun apply(ctx: Context, project: Project, vcs_builder: VCSBuilder) =>
     ctx.uout.info("run: " + " ".join(args.values()))
 
     // Build a : separated path from bundle roots.

--- a/corral/cmd/cmd_type.pony
+++ b/corral/cmd/cmd_type.pony
@@ -1,7 +1,8 @@
 use "../bundle"
+use "../vcs"
 
 trait CmdType
   fun requires_bundle(): Bool => true
   fun requires_no_bundle(): Bool => false
 
-  fun ref apply(ctx: Context, project: Project)
+  fun ref apply(ctx: Context, project: Project, vcs_builder: VCSBuilder)

--- a/corral/cmd/cmd_version.pony
+++ b/corral/cmd/cmd_version.pony
@@ -1,6 +1,7 @@
 use "cli"
 use ".."
 use "../bundle"
+use "../vcs"
 
 class CmdVersion is CmdType
 
@@ -8,5 +9,5 @@ class CmdVersion is CmdType
 
   fun requires_bundle(): Bool => false
 
-  fun apply(ctx: Context, project: Project) =>
+  fun apply(ctx: Context, project: Project, vcs_builder: VCSBuilder) =>
     ctx.uout.info("version: " + Version())

--- a/corral/cmd/executor.pony
+++ b/corral/cmd/executor.pony
@@ -2,6 +2,7 @@ use "files"
 use "../bundle"
 use "../util"
 use "debug"
+use "../vcs"
 
 primitive Executor
   """
@@ -102,4 +103,5 @@ primitive Executor
 
     let context = Context(env, log, uout, nothing, repo_cache)
     let project = Project(auth, log, bundle_dir)
-    command(context, project)
+    let vcs_builder = VCSBuilder(env)
+    command(context, project, vcs_builder)

--- a/corral/vcs/vcs.pony
+++ b/corral/vcs/vcs.pony
@@ -22,20 +22,6 @@ class val Repo
 
   fun is_remote(): Bool => remote != ""
 
-primitive VCSForType
-  """
-  This factory returns a VCS instance for any given VCS by name.
-  """
-  fun apply(env: Env, kind: String): VCS val ? =>
-    match kind
-    | "git" => GitVCS(env)?
-    | "hg"  => HgVCS
-    | "bzr" => BzrVCS
-    | "svn" => SvnVCS
-    else
-      NoneVCS
-    end
-
 interface val VCS
   """
   A Vcs provides functions to perform high-level VCS operations that commands

--- a/corral/vcs/vcs_builder.pony
+++ b/corral/vcs/vcs_builder.pony
@@ -1,0 +1,22 @@
+class val VCSBuilder
+  let _env: Env
+
+  new val create(env: Env) =>
+    _env = env
+
+  fun val apply(kind: String): VCS ? =>
+    """
+    Returns a VCS instance for any given VCS by name.
+    """
+
+    // TODO: this shouldn't be partial. That's a smell that
+    // a constructor can be partial
+
+    match kind
+    | "git" => GitVCS(_env)?
+    | "hg"  => HgVCS
+    | "bzr" => BzrVCS
+    | "svn" => SvnVCS
+    else
+      NoneVCS
+    end


### PR DESCRIPTION
This removes a primitive that had a match statement and moves
the functionality into a class that will be able to build a VCS
for use by commands.

This is a small step towards making commands unit-testable.