### PR TITLE
Add fetch tests

### DIFF
--- a/corral/cmd/_test.pony
+++ b/corral/cmd/_test.pony
@@ -9,3 +9,4 @@ actor Main is TestList
 
   fun tag tests(test: PonyTest) =>
    _TestCmdUpdate.make().tests(test)
+   _TestCmdFetch.make().tests(test)

--- a/corral/cmd/_test_cmd_fetch.pony
+++ b/corral/cmd/_test_cmd_fetch.pony
@@ -1,0 +1,102 @@
+use "files"
+use "ponytest"
+use "../bundle"
+use "../util"
+use "../vcs"
+
+actor _TestCmdFetch is TestList
+  new make() =>
+    None
+
+  fun tag tests(test: PonyTest) =>
+    test(_TestFetchEmptyDeps)
+    test(_TestFetchEmptyFile)
+    test(_TestFetchMutuallyRecursive)
+    test(_TestFetchSelfReferential)
+
+class iso _TestFetchEmptyDeps is UnitTest
+  """
+  Verify that when using corral.json with empty deps, that there
+  are never any sync, tag query, or checkout operations executed.
+  """
+
+  fun name(): String =>
+    "cmd/fetch/" + __loc.type_name()
+
+  fun apply(h: TestHelper) ? =>
+    _OpsRecorderFetchTestRunner(
+      h,
+      "empty-deps",
+      _OpsRecorder(h, 0, 0, 0))?
+
+class iso _TestFetchEmptyFile is UnitTest
+  """
+  Verify that when using corral.json with an empty deps file, that there
+  are never any sync, tag query, or checkout operations executed.
+  """
+
+  fun name(): String =>
+    "cmd/fetch/" + __loc.type_name()
+
+  fun apply(h: TestHelper) ? =>
+    _OpsRecorderFetchTestRunner(
+      h,
+      "empty-file",
+      _OpsRecorder(h, 0, 0, 0))?
+
+class iso _TestFetchSelfReferential is UnitTest
+  """
+  Verify that a self reference in a corral.json results in only 1 operation
+  """
+  fun name(): String =>
+    "cmd/fetch/" + __loc.type_name()
+
+  fun apply(h: TestHelper) ? =>
+    _OpsRecorderFetchTestRunner(
+      h,
+      "self-referential",
+      _OpsRecorder(h, 1, 0, 1))?
+
+class iso _TestFetchMutuallyRecursive is UnitTest
+  """
+  Verify that when using mutually recursive corral.json files that we
+  execute the correct number of operations
+  """
+
+  fun name(): String =>
+    "cmd/fetch/" + __loc.type_name()
+
+  fun apply(h: TestHelper) ? =>
+    _OpsRecorderFetchTestRunner(
+      h,
+      "mutually-recursive/foo",
+      _OpsRecorder(h, 2, 0, 2))?
+
+primitive _OpsRecorderFetchTestRunner
+  fun apply(h: TestHelper, dep_path: String val, recorder: _OpsRecorder) ? =>
+    """
+    Runs an _OpsRecorder test.
+    """
+    let auth = h.env.root as AmbientAuth
+    let log = Log(LvlNone, h.env.err, SimpleLogFormatter)
+    let fp: FilePath = _TestData.file_path_from(h, dep_path)?
+    let repo_cache = _TestRepoCache(auth, "_test_cmd_fetch_repo_cache")?
+    let ctx = Context(h.env, log, log, false, repo_cache)
+    let project = Project(auth, log, fp)
+    let bundle = Bundle.load(fp, log)?
+    let vcs_builder: VCSBuilder = _TestCmdFetchVCSBuilder(recorder)
+
+    let fetcher = _Fetcher(ctx, project, consume bundle, vcs_builder, 
+      recorder)
+
+    // when fetcher is finished, it will send a `cmd_completed` message to
+    // _OpsRecorder which will trigger pass/fail
+
+class val _TestCmdFetchVCSBuilder is VCSBuilder
+  let _recorder: _OpsRecorder
+
+  new val create(recorder: _OpsRecorder) =>
+    _recorder = recorder
+
+  fun val apply(kind: String): VCS =>
+    _RecordedVCS(_recorder)

--- a/corral/cmd/_test_cmd_update.pony
+++ b/corral/cmd/_test_cmd_update.pony
@@ -9,12 +9,12 @@ actor _TestCmdUpdate is TestList
     None
 
   fun tag tests(test: PonyTest) =>
-    test(_TestEmptyDeps)
-    test(_TestMutuallyRecursive)
-    test(_TestRegression120)
-    test(_TestSelfReferential)
+    test(_TestUpdateEmptyDeps)
+    test(_TestUpdateMutuallyRecursive)
+    test(_TestUpdateRegression120)
+    test(_TestUpdateSelfReferential)
 
-class iso _TestEmptyDeps is UnitTest
+class iso _TestUpdateEmptyDeps is UnitTest
   """
   Verify that when using an corral.json for with empty deps, that there
   are never any sync, tag query, or checkout operations executed.
@@ -24,12 +24,12 @@ class iso _TestEmptyDeps is UnitTest
     "cmd/update/" + __loc.type_name()
 
   fun apply(h: TestHelper) ? =>
-    _OpsRecorderTestRunner(
+    _OpsRecorderUpdateTestRunner(
       h,
       "empty-deps",
       _OpsRecorder(h, 0, 0, 0))?
 
-class iso _TestMutuallyRecursive is UnitTest
+class iso _TestUpdateMutuallyRecursive is UnitTest
   """
   Verify that when using mutually recursive corral.json files that we
   execute the correct number of operations
@@ -39,12 +39,12 @@ class iso _TestMutuallyRecursive is UnitTest
     "cmd/update/" + __loc.type_name()
 
   fun apply(h: TestHelper) ? =>
-    _OpsRecorderTestRunner(
+    _OpsRecorderUpdateTestRunner(
       h,
       "mutually-recursive/foo",
       _OpsRecorder(h, 2, 2, 2))?
 
-class iso _TestRegression120 is UnitTest
+class iso _TestUpdateRegression120 is UnitTest
   """
   Issue #120 identified a problem with transitive dependencies that resulted
   in too many operations being performaned across the loading of all
@@ -63,12 +63,12 @@ class iso _TestRegression120 is UnitTest
     "cmd/update/" + __loc.type_name()
 
   fun apply(h: TestHelper) ? =>
-    _OpsRecorderTestRunner(
+    _OpsRecorderUpdateTestRunner(
       h,
       "regression-120/bundle-entrypoint",
       _OpsRecorder(h, 4, 4, 4))?
 
-class iso _TestSelfReferential is UnitTest
+class iso _TestUpdateSelfReferential is UnitTest
   """
   Verify that a self reference in a corral.json results in only 1 operation
   """
@@ -76,12 +76,12 @@ class iso _TestSelfReferential is UnitTest
     "cmd/update/" + __loc.type_name()
 
   fun apply(h: TestHelper) ? =>
-    _OpsRecorderTestRunner(
+    _OpsRecorderUpdateTestRunner(
       h,
       "self-referential",
       _OpsRecorder(h, 1, 1, 1))?
 
-primitive _OpsRecorderTestRunner
+primitive _OpsRecorderUpdateTestRunner
   fun apply(h: TestHelper, dep_path: String val, recorder: _OpsRecorder) ? =>
     """
     Runs an _OpsRecorder test.
@@ -89,7 +89,7 @@ primitive _OpsRecorderTestRunner
     let auth = h.env.root as AmbientAuth
     let log = Log(LvlNone, h.env.err, SimpleLogFormatter)
     let fp: FilePath = _TestData.file_path_from(h, dep_path)?
-    let repo_cache = _TestRepoCache(auth)?
+    let repo_cache = _TestRepoCache(auth, "_test_cmd_update_repo_cache")?
     let ctx = Context(h.env, log, log, false, repo_cache)
     let project = Project(auth, log, fp)
     let bundle = Bundle.load(fp, log)?
@@ -101,40 +101,6 @@ primitive _OpsRecorderTestRunner
     // _OpsRecorder which will trigger pass/fail
     h.long_test(2_000_000_000)
 
-actor _OpsRecorder is CmdResultReceiver
-  let _h: TestHelper
-
-  let _expected_sync: U64
-  let _expected_tag_query: U64
-  let _expected_checkout: U64
-
-  var _sync: U64 = 0
-  var _tag_query: U64 = 0
-  var _checkout: U64 = 0
-
-  new create(h: TestHelper, s: U64, tq: U64, c: U64) =>
-    _h = h
-    _expected_sync = s
-    _expected_tag_query = tq
-    _expected_checkout = c
-
-  be sync() =>
-    _sync = _sync + 1
-
-  be tag_query() =>
-    _tag_query = _tag_query + 1
-
-  be checkout() =>
-    _checkout = _checkout + 1
-
-  be cmd_completed() =>
-    _h.assert_eq[U64](_expected_sync, _sync)
-    _h.assert_eq[U64](_expected_tag_query, _tag_query)
-    _h.assert_eq[U64](_expected_checkout, _checkout)
-
-    _h.complete(true)
-
-
 class val _TestCmdUpdateVCSBuilder is VCSBuilder
   let _recorder: _OpsRecorder
 
@@ -143,68 +109,3 @@ class val _TestCmdUpdateVCSBuilder is VCSBuilder
 
   fun val apply(kind: String): VCS =>
     _RecordedVCS(_recorder)
-
-
-class val _RecordedVCS is VCS
-  let _recorder: _OpsRecorder
-
-  new val create(recorder: _OpsRecorder) =>
-    _recorder = recorder
-
-  fun val sync_op(next: RepoOperation): RepoOperation =>
-    _RecordedSync(_recorder, next)
-
-  fun val tag_query_op(receiver: TagListReceiver): RepoOperation =>
-    _RecordedTagQuery(_recorder, receiver)
-
-  fun val checkout_op(rev: String, next: RepoOperation): RepoOperation =>
-    _RecordedCheckout(_recorder, next)
-
-
-class val _RecordedSync is RepoOperation
-  let _recorder: _OpsRecorder
-  let _next: RepoOperation
-
-  new val create(recorder: _OpsRecorder, next: RepoOperation) =>
-    _recorder = recorder
-    _next = next
-
-  fun val apply(repo: Repo) =>
-    _recorder.sync()
-    _next(repo)
-
-
-class val _RecordedTagQuery is RepoOperation
-  let _recorder: _OpsRecorder
-  let _next: TagListReceiver
-
-  new val create(recorder: _OpsRecorder, next: TagListReceiver) =>
-    _recorder = recorder
-    _next = next
-
-  fun val apply(repo: Repo) =>
-    let tags: Array[String] iso = recover Array[String] end
-    _recorder.tag_query()
-    _next(repo, consume tags)
-
-
-class val _RecordedCheckout is RepoOperation
-  let _recorder: _OpsRecorder
-  let _next: RepoOperation
-
-  new val create(recorder: _OpsRecorder, next: RepoOperation) =>
-    _recorder = recorder
-    _next = next
-
-  fun val apply(repo: Repo) =>
-    _recorder.checkout()
-    _next(repo)
-
-primitive _TestData
-  fun file_path_from(h: TestHelper, subdir: String = ""): FilePath ? =>
-    let auth = h.env.root as AmbientAuth
-    FilePath(auth, "corral/test/testdata")?.join(subdir)?
-
-primitive _TestRepoCache
-  fun apply(auth: AmbientAuth): FilePath ? =>
-    FilePath(auth,"_test_cmd_update_repo_cache")?

--- a/corral/cmd/_test_helpers.pony
+++ b/corral/cmd/_test_helpers.pony
@@ -1,0 +1,101 @@
+use "files"
+use "ponytest"
+use "../vcs"
+
+actor _OpsRecorder is CmdResultReceiver
+  let _h: TestHelper
+
+  let _expected_sync: U64
+  let _expected_tag_query: U64
+  let _expected_checkout: U64
+
+  var _sync: U64 = 0
+  var _tag_query: U64 = 0
+  var _checkout: U64 = 0
+
+  new create(h: TestHelper, s: U64, tq: U64, c: U64) =>
+    _h = h
+    _expected_sync = s
+    _expected_tag_query = tq
+    _expected_checkout = c
+
+  be sync() =>
+    _sync = _sync + 1
+
+  be tag_query() =>
+    _tag_query = _tag_query + 1
+
+  be checkout() =>
+    _checkout = _checkout + 1
+
+  be cmd_completed() =>
+    _h.assert_eq[U64](_expected_sync, _sync)
+    _h.assert_eq[U64](_expected_tag_query, _tag_query)
+    _h.assert_eq[U64](_expected_checkout, _checkout)
+
+    _h.complete(true)
+
+
+class val _RecordedVCS is VCS
+  let _recorder: _OpsRecorder
+
+  new val create(recorder: _OpsRecorder) =>
+    _recorder = recorder
+
+  fun val sync_op(next: RepoOperation): RepoOperation =>
+    _RecordedSync(_recorder, next)
+
+  fun val tag_query_op(receiver: TagListReceiver): RepoOperation =>
+    _RecordedTagQuery(_recorder, receiver)
+
+  fun val checkout_op(rev: String, next: RepoOperation): RepoOperation =>
+    _RecordedCheckout(_recorder, next)
+
+
+class val _RecordedSync is RepoOperation
+  let _recorder: _OpsRecorder
+  let _next: RepoOperation
+
+  new val create(recorder: _OpsRecorder, next: RepoOperation) =>
+    _recorder = recorder
+    _next = next
+
+  fun val apply(repo: Repo) =>
+    _recorder.sync()
+    _next(repo)
+
+
+class val _RecordedTagQuery is RepoOperation
+  let _recorder: _OpsRecorder
+  let _next: TagListReceiver
+
+  new val create(recorder: _OpsRecorder, next: TagListReceiver) =>
+    _recorder = recorder
+    _next = next
+
+  fun val apply(repo: Repo) =>
+    let tags: Array[String] iso = recover Array[String] end
+    _recorder.tag_query()
+    _next(repo, consume tags)
+
+
+class val _RecordedCheckout is RepoOperation
+  let _recorder: _OpsRecorder
+  let _next: RepoOperation
+
+  new val create(recorder: _OpsRecorder, next: RepoOperation) =>
+    _recorder = recorder
+    _next = next
+
+  fun val apply(repo: Repo) =>
+    _recorder.checkout()
+    _next(repo)
+
+primitive _TestData
+  fun file_path_from(h: TestHelper, subdir: String = ""): FilePath ? =>
+    let auth = h.env.root as AmbientAuth
+    FilePath(auth, "corral/test/testdata")?.join(subdir)?
+
+primitive _TestRepoCache
+  fun apply(auth: AmbientAuth, path: String): FilePath ? =>
+    FilePath(auth, path)?


### PR DESCRIPTION
- extracts test helpers (`OpsRecorder`, etc) from the `cmd/update` tests for usage with other `cmds`
- adds unit tests for `cmd/fetch` for the following scenarios:
  * empty-file
  * empty-deps
  * self-referential
  * mutually-recursive