### PR TITLE
Make corral less verbose

### DIFF
--- a/corral/main.pony
+++ b/corral/main.pony
@@ -25,21 +25,23 @@ actor Main
 
     let quiet = cmd.option("quiet").bool()
     let verbose = cmd.option("verbose").bool()
-    let ulvl = if verbose then LvlFine elseif quiet then LvlWarn else LvlInfo end
+    let ulvl = if verbose then LvlFine else LvlWarn end
+    let ulvl_info = if quiet then LvlWarn else LvlInfo end
     let uout = Log(ulvl, env.out, SimpleLogFormatter)
+    let uout_info = Log(ulvl_info, env.out, SimpleLogFormatter)
 
     // Create the specific command object
-    let command: CmdType = match cmd.fullname()
-      | "corral/add" => CmdAdd(cmd)
-      | "corral/clean" => CmdClean(cmd)
-      | "corral/fetch" => CmdFetch(cmd)
-      | "corral/info" => CmdInfo(cmd)
-      | "corral/init" => CmdInit(cmd)
-      | "corral/list" => CmdList(cmd)
-      | "corral/remove" => CmdRemove(cmd)
-      | "corral/run" => CmdRun(cmd)
-      | "corral/update" => CmdUpdate(cmd)
-      | "corral/version" => CmdVersion(cmd)
+    let command: (CmdType, Log) = match cmd.fullname()
+      | "corral/add" => (CmdAdd(cmd), uout)
+      | "corral/clean" => (CmdClean(cmd), uout)
+      | "corral/fetch" => (CmdFetch(cmd), uout)
+      | "corral/info" => (CmdInfo(cmd), uout_info)
+      | "corral/init" => (CmdInit(cmd), uout)
+      | "corral/list" => (CmdList(cmd), uout_info)
+      | "corral/remove" => (CmdRemove(cmd), uout)
+      | "corral/run" => (CmdRun(cmd), uout)
+      | "corral/update" => (CmdUpdate(cmd), uout)
+      | "corral/version" => (CmdVersion(cmd), uout_info)
       else
         log.err("Internal error: unexpected command: " + cmd.fullname())
         env.exitcode(2)
@@ -48,5 +50,5 @@ actor Main
 
     // Hand off to Executor to resolve required dirs and execute the command
     Executor.execute(
-      command, env, log, uout,
+      command._1, env, log, command._2,
       cmd.option("nothing").bool(), cmd.option("bundle_dir").string())

--- a/corral/test/integration/test_fetch.pony
+++ b/corral/test/integration/test_fetch.pony
@@ -21,6 +21,7 @@ class TestFetchEmpty is UnitTest
     Execute(h,
       recover [
         "fetch"
+        "--verbose"
         "--bundle_dir"; data.dir()
       ] end,
       {(h: TestHelper, ar: ActionResult)(data=data) =>
@@ -183,6 +184,7 @@ class TestFetchGithubDeep is UnitTest
     Execute(h,
       recover [
         "fetch"
+        "--verbose"
         "--bundle_dir"; data.dir()
       ] end,
       {(h: TestHelper, ar: ActionResult)(data=data) =>
@@ -218,6 +220,7 @@ class TestFetchRemoteGits is UnitTest
     Execute(h,
       recover [
         "fetch"
+        "--verbose"
         "--bundle_dir"; data.dir()
       ] end,
       {(h: TestHelper, ar: ActionResult)(data=data) =>

--- a/corral/test/integration/test_update.pony
+++ b/corral/test/integration/test_update.pony
@@ -10,6 +10,7 @@ class TestUpdateEmpty is UnitTest
     Execute(h,
       recover [
         "update"
+        "--verbose"
         "--bundle_dir"; Data(h, "empty-deps")?.path
       ] end,
       {(h: TestHelper, ar: ActionResult) =>
@@ -33,6 +34,7 @@ class TestUpdateGithub is UnitTest
     Execute(h,
       recover [
         "update"
+        "--verbose"
         "--bundle_dir"; data.dir()
       ] end,
       {(h: TestHelper, ar: ActionResult)(data=data) =>


### PR DESCRIPTION
This updates most non-log prints to stdout to have a log level of fine
such that they will only be displayed when the --verbose flag is passed.
Some commands are ommitted from this change, such as info, version, and
list as their explicit purpose is to print information.

Fixes #101 

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>