### PR TITLE
Increase timeouts for script tests

### DIFF
--- a/corral/test/integration/test_fetch.pony
+++ b/corral/test/integration/test_fetch.pony
@@ -141,7 +141,7 @@ class TestFetchScripts is UnitTest
     data.cleanup(h)
 
   fun apply(h: TestHelper) =>
-    h.long_test(8_000_000_000)
+    h.long_test(32_000_000_000)
     Execute(h,
       recover [ "fetch"; "--verbose"; "--bundle_dir"; data.dir() ] end,
       {(h: TestHelper, ar: ActionResult) =>

--- a/corral/test/integration/test_update.pony
+++ b/corral/test/integration/test_update.pony
@@ -65,7 +65,7 @@ class TestUpdateScripts is UnitTest
     data.cleanup(h)
 
   fun apply(h: TestHelper) =>
-    h.long_test(8_000_000_000)
+    h.long_test(32_000_000_000)
     Execute(h,
       recover [ "update"; "--verbose"; "--bundle_dir"; data.dir() ] end,
       {(h: TestHelper, ar: ActionResult) =>


### PR DESCRIPTION
PowerShell on Windows sometimes takes several seconds to start. This change increases the timeouts for the `integration/fetch/scripts` and `integration/update/scripts` tests so that the tests don't terminate before the script has written everything to stdout.

Hopefully this will make these tests less flaky.