### PR TITLE
Run PostFetchScript after fetch completion

### DIFF
--- a/.release-notes/160.md
+++ b/.release-notes/160.md
@@ -1,0 +1,5 @@
+## Fix bundle scripts running during fetch of git repository
+
+Corral was executing the bundle scripts while the git repository was being fetched. This was most noticable when downloading a bundle for the first time, as it was likely that the bundle file wasn't on disk when Corral tried to find the scripts to run.
+
+The fix waits for the repository to be successfully fetched before executing the bundle scripts.

--- a/corral/cmd/cmd_fetch.pony
+++ b/corral/cmd/cmd_fetch.pony
@@ -70,12 +70,14 @@ actor _Fetcher
         dep.version())
 
       let self: _Fetcher tag = this
-      let checkout_op = vcs.checkout_op(revision,
-        {(repo: Repo) => self.fetch_transitive_dep(dep.locator) })
+      let checkout_op = vcs.checkout_op(revision, {
+          (repo: Repo) => 
+            self.fetch_transitive_dep(dep.locator) 
+            PostFetchScript(ctx, repo)
+        } val)
       let fetch_op = vcs.sync_op(checkout_op)
 
       fetch_op(repo)
-      PostFetchScript(ctx, repo)
     else
       ctx.uout.err("Error fetching dep: " + dep.name() + " @ " + dep.version())
     end

--- a/corral/cmd/cmd_update.pony
+++ b/corral/cmd/cmd_update.pony
@@ -98,6 +98,7 @@ actor _Updater
     let checkout_op = vcs.checkout_op(revision, {
         (repo: Repo) =>
           self.load_transitive_dep(locator)
+          PostFetchScript(ctx, repo)
       } val)
 
     let tag_query_op = vcs.tag_query_op({
@@ -111,7 +112,6 @@ actor _Updater
       } val
     let sync_op = vcs.sync_op(sync_handler)
     sync_op(repo)
-    PostFetchScript(ctx, repo)
 
     deps_loading(locator) = dep
 


### PR DESCRIPTION
I believe `PostFetchScript` was intended to be called after the fetch was complete. But the call was placed such that it was running in parallel with the fetch. I noticed on the first fetch of a new repo that it doesn't find a bundle file, since the repo hasn't finished cloning yet.