### PR TITLE
Turn off cycle detector when running corral

### DIFF
--- a/corral/main.pony
+++ b/corral/main.pony
@@ -52,3 +52,6 @@ actor Main
     Executor.execute(
       command._1, env, log, command._2,
       cmd.option("nothing").bool(), cmd.option("bundle_dir").string())
+
+  fun @runtime_override_defaults(rto: RuntimeOptions) =>
+    rto.ponynoblock = true

--- a/corral/test/_test.pony
+++ b/corral/test/_test.pony
@@ -29,3 +29,6 @@ actor Main is TestList
     test(integration.TestUpdateScripts)
 
     cmd.Main.make().tests(test)
+
+  fun @runtime_override_defaults(rto: RuntimeOptions) =>
+    rto.ponynoblock = true


### PR DESCRIPTION
    Corral as currently constituted doesn't need the cycle detector so,
    it ends up just slowing the app down. But not a slow down you would
    notice.

    The bigger issue is that there is a race condition in the runtime
    at the moment that is present when the cycle detector is on and
    running corral tests triggers it sometimes.

    Until that issue is addressed, we should turn the cycle detector
    off so we don't get failures from a known source that we don't need to
    get them from.