### PR TITLE
Don't remove empty fields from configuration

### DIFF
--- a/.release-notes/164.md
+++ b/.release-notes/164.md
@@ -1,0 +1,3 @@
+## Don't remember empty optional fields from corral.json
+
+Empty "info" object fields were previously removed from corral.json. This made it hard to know what additional information you should be providing as a library author.

--- a/corral/bundle/json.pony
+++ b/corral/bundle/json.pony
@@ -49,9 +49,7 @@ primitive Json
     end
 
   fun set_string(jo: JsonObject, name: String, value: String) =>
-    if value != "" then
-      jo.data(name) = value
-    end
+    jo.data(name) = value
 
   fun string_must(jt: JsonType box, name: String): String ? =>
     (jt as JsonObject box).data(name)? as String

--- a/corral/test/integration/test_info.pony
+++ b/corral/test/integration/test_info.pony
@@ -14,7 +14,13 @@ class TestInfo is UnitTest
       ] end,
       {(h: TestHelper, ar: ActionResult) =>
         h.assert_eq[I32](0, ar.exit_code())
-        h.assert_true(ar.stdout.contains("info: {}"))
+        @printf[I32]("%s\n".cstring(), ar.stdout.cstring())
+        h.assert_true(ar.stdout.contains("info: {"))
+        h.assert_true(ar.stdout.contains("\"description\":\"\""))
+        h.assert_true(ar.stdout.contains("\"homepage\":\"\""))
+        h.assert_true(ar.stdout.contains("\"license\":\"\""))
+        h.assert_true(ar.stdout.contains("\"version\":\"\""))
+        h.assert_true(ar.stdout.contains("\"name\":\"\""))
         h.complete(ar.exit_code() == 0)
       })
 


### PR DESCRIPTION
Prior to this commit, optional fields were being removed from corral.json.
For things like "info" that we want people to fill out, this is detrimenal
as there is no template for what to fill out.

Given that this is only impacting on "info", I think it makes sense to
change the behavior.