### PR TITLE
Add documentation_url to `info` section of `corral.json`

### DIFF
--- a/.release-notes/166.md
+++ b/.release-notes/166.md
@@ -2,4 +2,4 @@
 
 documentation_url will allow a forthcoming feature in the pony compiler to generate documentation for code that uses a given bundle to link to the documentation for that bundle from the code in question.
 
-For example, `ponylang/http` will have it's documentation link directly to the documentation for `ponylang/regex` and `ponylang/net_ssl` for types that come from those bundles.
+For example, `ponylang/http` will have its documentation link directly to the documentation for `ponylang/regex` and `ponylang/net_ssl` for types that come from those bundles.

--- a/.release-notes/166.md
+++ b/.release-notes/166.md
@@ -1,0 +1,5 @@
+## Add `documentation_url` entry to bundle manifest
+
+documentation_url will allow a forthcoming feature in the pony compiler to generate documentation for code that uses a given bundle to link to the documentation for that bundle from the code in question.
+
+For example, `ponylang/http` will have it's documentation link directly to the documentation for `ponylang/regex` and `ponylang/net_ssl` for types that come from those bundles.

--- a/corral/bundle/data.pony
+++ b/corral/bundle/data.pony
@@ -39,6 +39,7 @@ class InfoData
   var name: String
   var description: String
   var homepage: String
+  var documentation_url: String
   var license: String
   var version: String
 
@@ -46,6 +47,7 @@ class InfoData
     name = Json.string(jo, "name")
     description = Json.string(jo, "description")
     homepage = Json.string(jo, "homepage")
+    documentation_url =  Json.string(jo, "documentation_url")
     license = Json.string(jo, "license")
     version = Json.string(jo, "version")
 
@@ -54,6 +56,7 @@ class InfoData
     Json.set_string(jo, "name", name)
     Json.set_string(jo, "description", description)
     Json.set_string(jo, "homepage", homepage)
+    Json.set_string(jo, "documentation_url", documentation_url)
     Json.set_string(jo, "license", license)
     Json.set_string(jo, "version", version)
     jo

--- a/doc/design.md
+++ b/doc/design.md
@@ -42,6 +42,7 @@ The `corral.json` file is managed by the Corral tool, but can also be edited by 
   - **name**: The name of the bundle, which should be its canonical location. [is this redundant with its implicit location?]
   - **description**: More text description about the bundle.
   - **homepage**: URL of the bundle home page.
+  - **documentation_url**: URL of the documentation for the bundle
   - **license**: License type, e.g. BSD, MIT, Apache, etc., or URL to it.
   - **version**: The version of this bundle.
      [TODO: is this redundant with the tags + revision/commits? I think so.]

--- a/doc/design.md
+++ b/doc/design.md
@@ -42,7 +42,7 @@ The `corral.json` file is managed by the Corral tool, but can also be edited by 
   - **name**: The name of the bundle, which should be its canonical location. [is this redundant with its implicit location?]
   - **description**: More text description about the bundle.
   - **homepage**: URL of the bundle home page.
-  - **documentation_url**: URL of the documentation for the bundle
+  - **documentation_url**: URL of the documentation for the bundle, used in cross-linking during documentation generation of the package.
   - **license**: License type, e.g. BSD, MIT, Apache, etc., or URL to it.
   - **version**: The version of this bundle.
      [TODO: is this redundant with the tags + revision/commits? I think so.]


### PR DESCRIPTION
As part of the work I am doing on the pony library documentation
generation, this documentation_url is needed.

The documentation_url will allow a library to link to the documentation
of its dependencies from within its own documentation.