### PR TITLE
Add new `packages` field to corral.json

### DIFF
--- a/corral/bundle/bundle.pony
+++ b/corral/bundle/bundle.pony
@@ -11,6 +11,7 @@ class Bundle
   let dir: FilePath
   let log: Log
   let info: InfoData
+  let packages: Array[String]
   let deps: Map[String, Dep ref] = deps.create()
   let scripts: (ScriptsData | None)
   var modified: Bool = false
@@ -19,6 +20,7 @@ class Bundle
     dir = dir'
     log = log'
     info = InfoData(JsonObject)
+    packages = Array[String]
     log.info("Created bundle in " + dir.path)
     scripts = None
     modified = true
@@ -39,6 +41,7 @@ class Bundle
       end
     info = data.info
     scripts = data.scripts
+    packages = data.packages
 
     let lm = Map[String, LockData]
     try
@@ -109,11 +112,19 @@ class Bundle
   fun bundle_json(): JsonObject =>
     let jo: JsonObject = JsonObject
     jo.data("info") = info.json()
+
+    let packages_array = recover ref JsonArray end
+    for p in packages.values() do
+      packages_array.data.push(p)
+    end
+    jo.data("packages") = packages_array
+
     let deps_array = recover ref JsonArray end
     for d in deps.values() do
       deps_array.data.push(d.data.json())
     end
     jo.data("deps") = deps_array
+
     try
       jo.data("scripts") = (scripts as this->ScriptsData).json()
     end

--- a/corral/bundle/data.pony
+++ b/corral/bundle/data.pony
@@ -2,6 +2,7 @@ use "json"
 
 class BundleData
   let info: InfoData
+  let packages: Array[String]
   let deps: Array[DepData]
   let scripts: (ScriptsData | None)
 
@@ -9,6 +10,13 @@ class BundleData
     // TODO: iterate over jo's map and verify we just have "info" or "deps"
     // https://github.com/ponylang/corral/issues/64
     info = InfoData(Json.objekt(jo, "info"))
+
+    packages = Array[String]
+    let packages_array = Json.array(jo, "packages")
+    for pjt in packages_array.data.values() do
+      let s = try pjt as String else "" end
+      packages.push(s)
+    end
 
     deps = Array[DepData]
     let bundles_array = Json.array(jo, "deps")


### PR DESCRIPTION
The `packages` field is a new experimental field that will list all
packages that are part of a bundle that should be included for distribution.

At the moment, entries must be added by hand, this commit assures that
any that exist are not removed when corral manipulates the corral.json file.

Eventually, if this feature holds, we will have commands to add and remove
packages as well as a command to prepare for release. Releases, rather than
being a "repo over here with tag" can be hosted on services like GitHub packages
or cloudsmith and would only include the bare minumum needed for the package.

Initially, this field is being used to generate documentation that works across
library projects. Existing exploratory work for that is being done in the
ponylang/library-documentation-action repository.