### PR TITLE
Switch default branch to use when none is supplied to 'main`

### DIFF
--- a/.release-notes/171.md
+++ b/.release-notes/171.md
@@ -1,0 +1,7 @@
+## Change "unknown branch" default to 'main'
+
+GitHub has switched its default branch name from `master` to `main` for newly created repositories. Given this change, we expect that eventually most repositories will have their default branch named `main`, not `master`.
+
+Corral will now use `main` and not `master` for the branch to use when using git or hg repos as a source.
+
+Any corral.json dependency entries that aren't using a version should be updated to include `master` as the version to continue working as they did before or if you control the dependency, update its default branch to `main` and things will continue to work as before.

--- a/corral/cmd/constraints.pony
+++ b/corral/cmd/constraints.pony
@@ -60,12 +60,12 @@ primitive Constraints
     else
       try
         Constraints._parse_constraints(version)?
-        "master" // Is a constraint: use main until update.
+        "main" // Is a constraint: use main until update.
       else
         if version != "" then
           version  // Version is not a constraint, use that.
         else
-          "master"  // Get the latest master if no constraints at all.
+          "main"  // Get the latest main if no constraints at all.
         end
       end
     end


### PR DESCRIPTION
We are in the process of switching ponylang repos over from `master`
to `main` as the default branch to match GitHub's change for the
default name for new repos.

This commit switches corral to be in line with the new GitHub defaults.