### PR TITLE
Install release version of ponyc for FreeBSD

### DIFF
--- a/.ci-scripts/freebsd-12.2-install-pony-tools.bash
+++ b/.ci-scripts/freebsd-12.2-install-pony-tools.bash
@@ -7,5 +7,5 @@
 
 cd /tmp || exit 1
 mkdir ponyc
-curl -O 'https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-x86-64-unknown-freebsd-12.2.tar.gz'
+curl -O 'https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-unknown-freebsd-12.2.tar.gz'
 tar -xvf ponyc-x86-64-unknown-freebsd-12.2.tar.gz -C ponyc --strip-components=1


### PR DESCRIPTION
We were using a nightly version of FreeBSD-12.2 of ponyc as there
was no release version yet.