### PR TITLE
Update to match breaking API change in the pony standard library

### DIFF
--- a/.release-notes/184.md
+++ b/.release-notes/184.md
@@ -1,0 +1,3 @@
+## Forward prepare for coming breaking change in ponyc
+
+This change has no impact on end users, but will future proof against a coming breaking change in the standard library. Users of this version of corral won't be impacted by the coming change.

--- a/corral/cmd/cmd_run.pony
+++ b/corral/cmd/cmd_run.pony
@@ -44,7 +44,7 @@ class CmdRun is CmdType
     try
       let prog = Program(ctx.env, args(0)?)?
       let vars = if ponypath.size() > 0 then
-          recover val ["PONYPATH=" + ponypath] .> append(ctx.env.vars) end
+          recover val [as String: "PONYPATH=" + ponypath] .> append(ctx.env.vars) end
         else
           ctx.env.vars
         end

--- a/corral/vcs/git.pony
+++ b/corral/vcs/git.pony
@@ -47,7 +47,7 @@ class val GitSyncRepo is RepoOperation
     end
 
   fun val _clone(repo: Repo) =>
-    let remote_uri = "https://" + repo.remote
+    let remote_uri = recover val "https://" + repo.remote end
     // Maybe: --recurse-submodules --quiet --verbose
     let action = Action(git.prog,
       recover ["clone"; "--no-checkout"; remote_uri; repo.local.path] end,


### PR DESCRIPTION
This change is backwards compatible with ponyc 0.40.0