### PR TITLE
Fix debug logging being set to Fine

### DIFF
--- a/corral/cli.pony
+++ b/corral/cli.pony
@@ -27,7 +27,7 @@ primitive CLI
       [
         OptionSpec.u64(
           "debug",
-          "Configure debug output: 0=off, 1=err, 2=warn, 3=info, 4=fine."
+          "Configure debug output: 0=err, 1=warn, 2=info, 3=fine."
           where short'='g',
           default' = 0)
         OptionSpec.bool(

--- a/corral/main.pony
+++ b/corral/main.pony
@@ -13,7 +13,7 @@ actor Main
         if exit_code == 0 then
           env.out.print(msg)
         else
-          StringLogger(Error, env.err).log(msg)
+          StringLogger(Error, env.err, SimpleLogFormatter).log(msg)
           env.out.print(CLI.help())
           env.exitcode(exit_code.i32())
         end
@@ -22,7 +22,7 @@ actor Main
 
     // Setup options and helpers used by commands
     let debug = cmd.option("debug").u64()
-    let log = StringLogger(Fine, env.err)
+    let log = StringLogger(DebugLevel(debug), env.err, SimpleLogFormatter)
 
     let quiet = cmd.option("quiet").bool()
     let verbose = cmd.option("verbose").bool()

--- a/corral/util/log.pony
+++ b/corral/util/log.pony
@@ -1,5 +1,16 @@
 use "logger"
 
+primitive DebugLevel
+  fun apply(lvl: U64): LogLevel =>
+    match lvl
+    | 0 => Error
+    | 1 => Warn
+    | 2 => Info
+    | 3 => Fine
+    else
+      Fine
+    end
+
 primitive SimpleLogFormatter is LogFormatter
   fun apply(msg: String, loc: SourceLoc): String =>
     msg


### PR DESCRIPTION
When I originally implemented #185, I followed @rkallos changes, which used `Fine` as the level for the debug output. This was a mistake (the code was WIP, so that's on me).

Unfortunately, the original implementation of debug output had an "off" option that is not compatible with the standard `logger` package: there's no way to completely suppress output. To cope with this, I changed the help output of the `debug` option so that the minimum debug option is "err".

I don't think this needs release notes, since the original change was never included in a release. 