### PR TITLE
Fix flakey test setup

### DIFF
--- a/corral/test/util.pony
+++ b/corral/test/util.pony
@@ -121,3 +121,5 @@ primitive Copy
     while from_file.errno() is FileOK do
       to_file.write(from_file.read(65536))
     end
+    from_file.dispose()
+    to_file.dispose()


### PR DESCRIPTION
This was always seen on Windows where integration tests would sometimes
fail because the test file to be used hadn't yet been closed by it's
setup so it was unavailable to be used and we would get this error
hidden in stdout:

2021-07-15T03:49:18.1791520Z The process cannot access the file
'D:\a\corral\corral\test_scratch.ew7i6j\scripted\test.ps1' because it is
being used