### PR TITLE
Fixed bug where `corral update` would result in incorrect code in the corral

### DIFF
--- a/.release-notes/update-finishes-correct.md
+++ b/.release-notes/update-finishes-correct.md
@@ -1,0 +1,3 @@
+## Fixed bug where corral update would result in incorrect code in the corral
+
+When a dependency had a version constraint rather than a single value, the first time `corral update` was run, you wouldn't end up with the correct code checked out. The constraint was correctly solved, but the checked out code would be for branch `main`. 


### PR DESCRIPTION
    When a dependency had a version constraint rather than a single value,
    the first time `corral update` was run, you wouldn't end up with the
    correct code checked out. The constraint was correctly solved, but the
    checked out code would be for branch `main`.

    The problem arose because we first have to check something out and then
    can do constraint solving.

    This commit makes the change to keep track of what "something" was that
    was initially checked out and if it differs from what we eventually
    determine the revision should be, we run another update to get the
    contents of `_corral` into the correct state.