### PR TITLE
Update corral to work with latest ponyc nightly

### DIFF
--- a/.ci-scripts/freebsd-13.0-install-pony-tools.bash
+++ b/.ci-scripts/freebsd-13.0-install-pony-tools.bash
@@ -1,8 +1,21 @@
 #!/bin/bash
 
+case "${1}" in
+"release")
+  ;;
+"nightly")
+  ;;
+*)
+  echo "invalid ponyc version"
+  echo "Options:"
+  echo "release"
+  echo "nightly"
+  exit 1
+esac
+
 curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh | sh
 
 export PATH="$HOME/.local/share/ponyup/bin/:$PATH"
 
-ponyup update ponyc release
+ponyup update ponyc "${1}"
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,7 +15,7 @@ task:
     - echo "IGNORE_OSVERSION = yes" >> /usr/local/etc/pkg.conf
     - pkg update
     - pkg install -y bash git gmake
-    - bash .ci-scripts/freebsd-13.0-install-pony-tools.bash
+    - bash .ci-scripts/freebsd-13.0-install-pony-tools.bash release
 
   test_script:
     - export PATH="$HOME/.local/share/ponyup/bin/:$PATH"
@@ -47,7 +47,7 @@ task:
 
   nightly_script:
     - export PATH="$HOME/.local/share/ponyup/bin/:$PATH"
-    - bash .ci-scripts/release/x86-64-unknown-freebsd-13.0-nightly.bash
+    - bash .ci-scripts/release/x86-64-unknown-freebsd-13.0-nightly.bash release
 
 #
 # Release build tasks
@@ -71,7 +71,7 @@ task:
     - pkg update
     - pkg install -y bash gmake git py38-pip
     - pip install --upgrade cloudsmith-cli
-    - bash .ci-scripts/freebsd-13.0-install-pony-tools.bash
+    - bash .ci-scripts/freebsd-13.0-install-pony-tools.bash release
 
   release_script:
     - export PATH="$HOME/.local/share/ponyup/bin/:$PATH"

--- a/corral/bundle/project.pony
+++ b/corral/bundle/project.pony
@@ -18,7 +18,7 @@ primitive BundleDir
     while dir'.size() > 0 do
       log(Info) and log.log("Looking for " + Files.bundle_filename() + " in: '" + dir' + "'")
       try
-        let dir_path = FilePath(auth, dir')?
+        let dir_path = FilePath(auth, dir')
         let bundle_file = dir_path.join(Files.bundle_filename())?
         if bundle_file.exists() then
           return dir_path
@@ -32,7 +32,7 @@ primitive BundleDir
   fun resolve(auth: AmbientAuth, dir: String, log: Logger[String]): (FilePath | None) =>
     log(Info) and log.log("Checking for " + Files.bundle_filename() + " in: '" + dir + "'")
     try
-      let dir_path = FilePath(auth, dir)?
+      let dir_path = FilePath(auth, dir)
       let bundle_file = dir_path.join(Files.bundle_filename())?
       if bundle_file.exists() then
         return dir_path
@@ -81,7 +81,7 @@ class val Project
 
   fun dep_bundle_root(locator: Locator): FilePath ? =>
     let root = if locator.is_local_direct() then
-      FilePath(auth, Path.join(dir.path, locator.bundle_path))?
+      FilePath(auth, Path.join(dir.path, locator.bundle_path))
     else
       corral_dirpath()?.join(Path.join(locator.flat_name(), locator.bundle_path))?
     end

--- a/corral/cmd/_test_cmd_update.pony
+++ b/corral/cmd/_test_cmd_update.pony
@@ -90,7 +90,7 @@ primitive _OpsRecorderTestRunner
     let auth = h.env.root as AmbientAuth
     let log = StringLogger(Error, h.env.err, SimpleLogFormatter)
     let fp: FilePath = _TestData.file_path_from(h, dep_path)?
-    let repo_cache = _TestRepoCache(auth)?
+    let repo_cache = _TestRepoCache(auth)
     let ctx = Context(h.env, log, log, false, repo_cache)
     let project = Project(auth, log, fp)
     let bundle = Bundle.load(fp, log)?
@@ -204,8 +204,8 @@ class val _RecordedCheckout is RepoOperation
 primitive _TestData
   fun file_path_from(h: TestHelper, subdir: String = ""): FilePath ? =>
     let auth = h.env.root as AmbientAuth
-    FilePath(auth, "corral/test/testdata")?.join(subdir)?
+    FilePath(auth, "corral/test/testdata").join(subdir)?
 
 primitive _TestRepoCache
-  fun apply(auth: AmbientAuth): FilePath ? =>
-    FilePath(auth,"_test_cmd_update_repo_cache")?
+  fun apply(auth: AmbientAuth): FilePath =>
+    FilePath(auth,"_test_cmd_update_repo_cache")

--- a/corral/cmd/cmd_pack.pony
+++ b/corral/cmd/cmd_pack.pony
@@ -23,7 +23,7 @@ class CmdPack is CmdType
     match project.load_bundle()
     | let bundle: Bundle =>
       try
-        let path = FilePath(project.auth, _output)?
+        let path = FilePath(project.auth, _output)
         if not path.mkdir() then
           ctx.uout(Error) and
             ctx.uout.log("pack: unable to create " + _output)
@@ -31,7 +31,7 @@ class CmdPack is CmdType
 
         let car_name: String = bundle.info.name + "-" + bundle.info.version + ".car"
         let car_path = Path.join(_output, car_name)
-        let car_file_path = FilePath(project.auth, car_path)?
+        let car_file_path = FilePath(project.auth, car_path)
 
         let corral_file = project.dir.join(Files.bundle_filename())?
 
@@ -40,7 +40,7 @@ class CmdPack is CmdType
 
         let sorted_packages = Sort[Array[String], String](bundle.packages)
         for package in sorted_packages.values() do
-          encoder.add(FilePath(project.dir, package)?)?
+          encoder.add(FilePath.from(project.dir, package)?)?
         end
 
         encoder.write(car_file_path)?

--- a/corral/cmd/executor.pony
+++ b/corral/cmd/executor.pony
@@ -67,7 +67,7 @@ primitive Executor
         return
       else
         try
-          let fp = FilePath(auth, bundle_dir_str)?
+          let fp = FilePath(auth, bundle_dir_str)
           if not FileInfo(fp)?.directory then error end
         else
           uout(Error) and uout.log("Error: could not access directory for new bundle: " + bundle_dir_str)
@@ -81,13 +81,7 @@ primitive Executor
     let bundle_dir: FilePath =
       match bundle_dir_maybe
       | let fp: FilePath => fp
-      | None => try
-          FilePath(auth, bundle_dir_str)?  // placeholder for create
-        else
-          log(Error) and log.log("Internal error: unexpected state.")
-          env.exitcode(2)
-          return
-        end
+      | None => FilePath(auth, bundle_dir_str)  // placeholder for create
       end
 
     // Make a FilePath for the repo cache dir

--- a/corral/cmd/repo.pony
+++ b/corral/cmd/repo.pony
@@ -16,14 +16,14 @@ primitive RepoForDep
       // Local-direct (non-vcs) locator points to the workspace directly
       if dep.locator.is_local_direct() then
         let ws_str = Path.join(dep.bundle.dir.path, dep.locator.bundle_path)
-        let workspace = FilePath(auth, ws_str)?
-        Repo("", FilePath(auth, "")?, workspace)
+        let workspace = FilePath(auth, ws_str)
+        Repo("", FilePath(auth, ""), workspace)
       else
         let workspace = project.dep_workspace_root(dep.locator)?
 
         // Local-vcs has no remote component, just local repo and workspace
         if dep.locator.is_local_vcs() then
-          Repo("", FilePath(auth, dep.locator.repo_path)?, workspace)
+          Repo("", FilePath(auth, dep.locator.repo_path), workspace)
 
         // Remote-vcs has remote repo, local repo, and workspace
         elseif dep.locator.is_remote_vcs() then

--- a/corral/test/util.pony
+++ b/corral/test/util.pony
@@ -32,7 +32,7 @@ primitive Execute
 primitive Data
   fun apply(h: TestHelper, subdir: String = ""): FilePath ? =>
     let auth = h.env.root as AmbientAuth
-    FilePath(auth, "corral/test/testdata")?.join(subdir)?
+    FilePath(auth, "corral/test/testdata").join(subdir)?
 
 
 class val DataClone
@@ -41,7 +41,7 @@ class val DataClone
 
   new val create(h: TestHelper, subdirs: (Array[String] val | String | None) = None) ? =>
     let auth = h.env.root as AmbientAuth
-    let src_root = FilePath(auth, "corral/test/testdata")?
+    let src_root = FilePath(auth, "corral/test/testdata")
 
     _root = FilePath.mkdtemp(auth, "test_scratch.")?
 

--- a/corral/util/action.pony
+++ b/corral/util/action.pony
@@ -15,7 +15,7 @@ class val Program
   =>
     auth = env.root as AmbientAuth
     path = if Path.is_abs(name) then
-      FilePath(auth, name)?
+      FilePath(auth, name)
     else
       (let evars, let pathkey) =
         ifdef windows then
@@ -32,14 +32,14 @@ class val Program
   =>
     for bindir in Path.split_list(binpath).values() do
       try
-        let bd = FilePath(auth', bindir)?
+        let bd = FilePath(auth', bindir)
         ifdef windows then
-          let bin_bare = FilePath(bd, name)?
+          let bin_bare = FilePath.from(bd, name)?
           if bin_bare.exists() then return bin_bare end
-          let bin_exe = FilePath(bd, name + ".exe")?
+          let bin_exe = FilePath.from(bd, name + ".exe")?
           if bin_exe.exists() then return bin_exe end
         else
-          let bin = FilePath(bd, name)?
+          let bin = FilePath.from(bd, name)?
           if bin.exists() then
             // TODO: should also stat for executable. FileInfo(bin)
             return bin


### PR DESCRIPTION
Changes are all related to RFC 70.

Once the next version of ponyc is released, PR CI tasks need to be
switched back from using nightly to release.