### PR TITLE
Support for using ponyup on Windows

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -1,7 +1,7 @@
 Param(
-  [Parameter(Position=0, Mandatory=$true, HelpMessage="The action to take (build, test, install, package, clean).")]
+  [Parameter(Position=0, HelpMessage="The action to take (build, test, install, package, clean).")]
   [string]
-  $Command,
+  $Command = 'build',
 
   [Parameter(HelpMessage="The build configuration (Release, Debug).")]
   [string]
@@ -84,7 +84,7 @@ function BuildCorral
   {
     if ($binaryTimestamp -lt $file.LastWriteTimeUtc)
     {
-      ponyc.exe "$configFlag" --cpu "$Arch" --output "$buildDir" "$srcDir"
+      ponyc "$configFlag" --cpu "$Arch" --output "$buildDir" "$srcDir"
       break buildFiles
     }
   }


### PR DESCRIPTION
Ponyup on Windows creates batch files in its bin directory to select the current version of its tools. This PR changes `ponyc.exe` in `make.ps1` to `ponyc`, which will correctly call ponyup's batch file.

It also makes `build` the default command for `make.ps1`.