### PR TITLE
Avoid using backslashes in locator paths

### DIFF
--- a/corral/bundle/locator.pony
+++ b/corral/bundle/locator.pony
@@ -36,14 +36,14 @@ class val Locator is (su.ComparableMixin[Locator] & Hashable & Stringable)
 
   fun path(): String =>
     """Returns a unique name for this locator without the vcs suffix."""
-    Path.join(repo_path, bundle_path)
+    Path.to_slash(Path.join(repo_path, bundle_path))
 
   fun flat_name(): String =>
     _Flattened(path())
 
   fun string(): String iso^ =>
     """Returns the full string for of this locator."""
-    Path.join(repo_path + vcs_suffix, bundle_path).clone()
+    Path.to_slash(Path.join(repo_path + vcs_suffix, bundle_path)).clone()
 
   fun compare(that: Locator box): Compare =>
     if (repo_path != that.repo_path) then return repo_path.compare(that.repo_path) end

--- a/corral/test/integration/test_update.pony
+++ b/corral/test/integration/test_update.pony
@@ -146,6 +146,18 @@ class  \nodoc\ TestUpdateGithub is UnitTest
           let lock_file = data.dir_path("lock.json")?
           h.assert_true(lock_file.exists())
 
+          // Check for backslashes in locators
+          with file = File.open(lock_file) do
+            for line in file.lines() do
+              if line.contains("locator") and line.contains("\\") then
+                h.fail("lock file locator contains backslashes")
+                h.complete(false)
+                return
+              end
+            end
+          end
+
+          // Check for the _repos dir
           let repos_dir = data.dir_path("_repos")?
           h.assert_true(repos_dir.exists())
 


### PR DESCRIPTION
We were using `Path.join` to construct locator paths for lock files. On Windows, this will use backslashes, which for locators that are URL paths, is incorrect. This PR makes all locator paths use forward slashes instead. This is OK on Windows even for local filesystem dependencies since Windows understands forward slashes.

Also adds a check in one of the update tests to make sure there aren't backslashes in the generated `lock.json`.

Fixes #214