### PR TITLE
Fix resolving relative paths with `corral run`

### DIFF
--- a/.release-notes/216.md
+++ b/.release-notes/216.md
@@ -1,0 +1,11 @@
+## Fix resolving relative paths for `corral run`
+
+Corral was failing when running commands with a relative path to the binary. E.g. `../../build/debug/ponyc`.
+This change switches relative binary resolution from using [`FilePath.from`](https://stdlib.ponylang.io/files-FilePath/#from) to [`Path.join`](https://stdlib.ponylang.io/files-Path/#join), in order to not fail if a path points to a parent directory, which is an error condition for [`FilePath.from`](https://stdlib.ponylang.io/files-FilePath/#from).
+
+`corral run` now also resolves relative paths against the current working directory first, before checking the `$PATH` environment variable.
+
+## Improved Error messages for `corral run`
+
+`corral run` will now print more detailed error messages when it is not able to run the given command.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Corral will be documented in this file. This project adhe
 
 ### Fixed
 
+- Improved error messages for `corral run` ([PR #216](https://github.com/ponylang/corral/pull/216))
+
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ All notable changes to Corral will be documented in this file. This project adhe
 
 - Improved error messages for `corral run` ([PR #216](https://github.com/ponylang/corral/pull/216))
 
-
 ### Added
 
 

--- a/corral/test/_test.pony
+++ b/corral/test/_test.pony
@@ -26,6 +26,10 @@ actor \nodoc\ Main is TestList
     test(integration.TestUpdateSelfReferential)
     test(integration.TestRun)
     test(integration.TestRunWithoutBundle)
+    test(integration.TestRunNoArgs)
+    test(integration.TestRunBinaryNotFound)
+    test(integration.TestRunBinaryNotFoundAbsolute)
+    test(integration.TestRunBinaryInParentFolder)
     test(integration.TestClean)
 
     test(integration.TestUpdateScripts)

--- a/corral/test/integration/test_run.pony
+++ b/corral/test/integration/test_run.pony
@@ -3,7 +3,7 @@ use "ponytest"
 use ".."
 use "../../util"
 
-class  \nodoc\ TestRun is UnitTest
+class \nodoc\ TestRun is UnitTest
   fun name(): String => "integration/run"
   fun apply(h: TestHelper) ? =>
     h.long_test(30_000_000_000)
@@ -20,7 +20,7 @@ class  \nodoc\ TestRun is UnitTest
         h.complete(ar.exit_code() == 0)
       })
 
-class  \nodoc\ TestRunWithoutBundle is UnitTest
+class \nodoc\ TestRunWithoutBundle is UnitTest
   fun name(): String => "integration/run/without-bundle"
   fun apply(h: TestHelper) =>
     h.long_test(30_000_000_000)
@@ -28,6 +28,81 @@ class  \nodoc\ TestRunWithoutBundle is UnitTest
       recover [
         "run"
         "--bundle_dir"; "/"
+        "--"
+        "ponyc"; "-version"
+      ] end,
+      {(h: TestHelper, ar: ActionResult) =>
+        h.assert_eq[I32](0, ar.exit_code())
+        h.assert_true(ar.stdout.lower().contains("compiled with: "))
+        h.complete(ar.exit_code() == 0)
+      })
+class \nodoc\ TestRunNoArgs is UnitTest
+  fun name(): String => "integration/run/no-args"
+  fun apply(h: TestHelper) ? =>
+    h.long_test(30_000_000_000)
+    Execute(h,
+      recover [
+        "run"
+        "--bundle_dir"; Data(h, "empty-deps")?.path
+        "--"
+      ] end,
+      {(h: TestHelper, ar: ActionResult) =>
+        h.assert_eq[I32](1, ar.exit_code())
+        h.assert_true(ar.stdout.lower().contains("no run command provided"))
+        h.complete(ar.exit_code() == 1)
+      })
+
+class \nodoc\ TestRunBinaryNotFound is UnitTest
+  fun name(): String => "integration/run/binary-not-found"
+  fun apply(h: TestHelper) ? =>
+    h.long_test(30_000_000_000)
+    Execute(h,
+      recover [
+        "run"
+        "--bundle_dir"; Data(h, "empty-deps")?.path
+        "--"
+        "grmpf_i_do_not_exist_anywhere_and_i_am_not_absolute"
+      ] end,
+      {(h: TestHelper, ar: ActionResult) =>
+        h.assert_eq[I32](1, ar.exit_code())
+        h.assert_true(ar.stdout.lower().contains("unable to find binary \"grmpf_i_do_not_exist_anywhere_and_i_am_not_absolute\""))
+        h.complete(ar.exit_code() == 1)
+      })
+
+class \nodoc\ TestRunBinaryNotFoundAbsolute is UnitTest
+  fun name(): String => "integration/run/binary-not-found-absolute"
+  fun apply(h: TestHelper) ? =>
+    h.long_test(30_000_000_000)
+    Execute(h,
+      recover [
+        "run"
+        "--bundle_dir"; Data(h, "empty-deps")?.path
+        "--"
+        "/path/to/grmpf_i_do_not_exist_anywhere"
+      ] end,
+      {(h: TestHelper, ar: ActionResult) =>
+        ar.print_to(h.env.out)
+        h.assert_eq[I32](255, ar.exit_code())
+        h.assert_true(ar.stdout.lower().contains("/path/to/grmpf_i_do_not_exist_anywhere does not exist or is a directory"))
+        h.complete(ar.exit_code() == 255)
+      })
+
+class \nodoc\ TestRunBinaryInParentFolder is UnitTest
+  fun name(): String => "integration/run/binary-in-parent-folder"
+  fun apply(h: TestHelper) ? =>
+    let cwd = Path.cwd()
+    let ponyc_path = try
+      RelativePathToPonyc(h)?
+    else
+      h.log("Unable to determine relative path to ponyc, skipping.")
+      return
+    end
+    h.log(ponyc_path)
+    h.long_test(30_000_000_000)
+    Execute(h,
+      recover [
+        "run"
+        "--bundle_dir"; Data(h, "empty-deps")?.path
         "--"
         "ponyc"; "-version"
       ] end,

--- a/corral/test/integration/test_run.pony
+++ b/corral/test/integration/test_run.pony
@@ -73,17 +73,17 @@ class \nodoc\ TestRunBinaryNotFoundAbsolute is UnitTest
   fun name(): String => "integration/run/binary-not-found-absolute"
   fun apply(h: TestHelper) ? =>
     h.long_test(30_000_000_000)
+    let path = Path.join("/path/to", "grmpf_i_do_not_exist_anywhere")
     Execute(h,
       recover [
         "run"
         "--bundle_dir"; Data(h, "empty-deps")?.path
         "--"
-        "/path/to/grmpf_i_do_not_exist_anywhere"
+        path
       ] end,
       {(h: TestHelper, ar: ActionResult) =>
-        ar.print_to(h.env.out)
         h.assert_ne[I32](0, ar.exit_code())
-        h.assert_true(ar.stdout.lower().contains("/path/to/grmpf_i_do_not_exist_anywhere does not exist or is a directory"))
+        h.assert_true(ar.stdout.lower().contains(path + " does not exist or is a directory"))
         h.complete(ar.exit_code() != 0)
       })
 

--- a/corral/test/integration/test_run.pony
+++ b/corral/test/integration/test_run.pony
@@ -82,9 +82,9 @@ class \nodoc\ TestRunBinaryNotFoundAbsolute is UnitTest
       ] end,
       {(h: TestHelper, ar: ActionResult) =>
         ar.print_to(h.env.out)
-        h.assert_eq[I32](255, ar.exit_code())
+        h.assert_ne[I32](0, ar.exit_code())
         h.assert_true(ar.stdout.lower().contains("/path/to/grmpf_i_do_not_exist_anywhere does not exist or is a directory"))
-        h.complete(ar.exit_code() == 255)
+        h.complete(ar.exit_code() != 0)
       })
 
 class \nodoc\ TestRunBinaryInParentFolder is UnitTest

--- a/corral/test/util.pony
+++ b/corral/test/util.pony
@@ -1,9 +1,11 @@
 use "cli"
 use "files"
+use "strings"
 use "ponytest"
 use "../util"
 
-interface  \nodoc\ val Checker
+
+interface \nodoc\ val Checker
   fun apply(h: TestHelper, ar: ActionResult)
 
 
@@ -75,3 +77,32 @@ class \nodoc\ val DataNone
   fun cleanup(h: TestHelper) => None
   fun dir(): String => ""
   fun dir_path(subdir: String): FilePath ? => error
+
+
+primitive RelativePathToPonyc
+  fun apply(h: TestHelper): String ? =>
+    var cwd = Path.cwd()
+    var ponyc_rel_path: String trn = recover trn String.create() end
+    let env = EnvVars(h.env.vars)
+    let path =
+      ifdef windows then
+        env("path")?
+      else
+        env("PATH")?
+      end
+    for bindir in Path.split_list(path).values() do
+      let ponyc_path = FilePath(h.env.root, Path.join(bindir, "ponyc"))
+      if ponyc_path.exists() then
+        let prefix: String val = CommonPrefix([cwd; ponyc_path.path])
+        while cwd.size() > prefix.size() do
+          cwd = Path.dir(cwd)
+          ponyc_rel_path = ponyc_rel_path + ".." + Path.sep()
+        end
+        ponyc_rel_path = ponyc_rel_path + ponyc_path.path.substring(prefix.size().isize())
+        return (consume ponyc_rel_path)
+      end
+    end
+    error
+
+
+


### PR DESCRIPTION
The logic to determine the absolute path to an executable was using `FilePath.from(base, subdir)` which errors if the resulting path is not below the `base`. This is the case if `subdir` is e.g. `../foo`.

This fix stems from trying to execute:

```
$ corral run -- ../../ponyc/build/debug/ponyc
run: couldn't run program: ../../ponyc/build/debug/ponyc .
```

The error output is clearly not really informative.
With this PR the above command actually runs the existing ponyc.

Other changes in here all related to improving `corral run`:
* First try to resolve relative paths against the current working directory, then against `$PATH`. This enables running relative paths to parent folders (See the above command).
* Display different errors if no args were provided or the executable to run could not be found

