### PR TITLE
Add nightly builds for MacOS on Apple Silicon

### DIFF
--- a/.ci-scripts/MacOS-arm64-install-pony-tools.bash
+++ b/.ci-scripts/MacOS-arm64-install-pony-tools.bash
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+case "${1}" in
+"release")
+  ;;
+"nightly")
+  ;;
+*)
+  echo "invalid ponyc version"
+  echo "Options:"
+  echo "release"
+  echo "nightly"
+  exit 1
+esac
+
+pushd /tmp || exit
+mkdir ponyc
+curl https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-arm64-apple-darwin.tar.gz --output ponyc.tar.gz
+tar xzf ponyc.tar.gz -C ponyc --strip-components=1
+popd || exit

--- a/.ci-scripts/release/arm64-apple-darwin-nightly.bash
+++ b/.ci-scripts/release/arm64-apple-darwin-nightly.bash
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# x86-64-unknown-linux release:
+#
+# - Builds release package
+# - Uploads to Cloudsmith
+#
+# Tools required in the environment that runs this:
+#
+# - bash
+# - cloudsmith-cli
+# - GNU gzip
+# - GNU make
+# - ponyc
+# - GNU tar
+
+set -o errexit
+
+# Pull in shared configuration specific to this repo
+base=$(dirname "$0")
+# shellcheck source=.ci-scripts/release/config.bash
+source "${base}/config.bash"
+
+# Verify ENV is set up correctly
+# We validate all that need to be set in case, in an absolute emergency,
+# we need to run this by hand. Otherwise the GitHub actions environment should
+# provide all of these if properly configured
+if [[ -z "${CLOUDSMITH_API_KEY}" ]]; then
+  echo -e "\e[31mCloudsmith API key needs to be set in CLOUDSMITH_API_KEY."
+  echo -e "Exiting.\e[0m"
+  exit 1
+fi
+
+if [[ -z "${GITHUB_REPOSITORY}" ]]; then
+  echo -e "\e[31mName of this repository needs to be set in GITHUB_REPOSITORY."
+  echo -e "\e[31mShould be in the form OWNER/REPO, for example:"
+  echo -e "\e[31m     ponylang/ponyup"
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
+if [[ -z "${APPLICATION_NAME}" ]]; then
+  echo -e "\e[31mAPPLICATION_NAME needs to be set."
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
+if [[ -z "${APPLICATION_SUMMARY}" ]]; then
+  echo -e "\e[31mAPPLICATION_SUMMARY needs to be set."
+  echo -e "\e[31mIt's a short description of the application that will appear in Cloudsmith."
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
+# no unset variables allowed from here on out
+# allow above so we can display nice error messages for expected unset variables
+set -o nounset
+
+TODAY=$(date +%Y%m%d)
+
+# Compiler target parameters
+MACHINE=arm64
+PROCESSOR=armv8
+
+# Triple construction
+VENDOR=apple
+OS=darwin
+TRIPLE=${MACHINE}-${VENDOR}-${OS}
+
+# Build parameters
+BUILD_PREFIX=$(mktemp -d)
+APPLICATION_VERSION="nightly-${TODAY}"
+BUILD_DIR=${BUILD_PREFIX}/${APPLICATION_VERSION}
+
+# Asset information
+PACKAGE_DIR=$(mktemp -d)
+PACKAGE=${APPLICATION_NAME}-${TRIPLE}
+
+# Cloudsmith configuration
+CLOUDSMITH_VERSION=${TODAY}
+ASSET_OWNER=ponylang
+ASSET_REPO=nightlies
+ASSET_PATH=${ASSET_OWNER}/${ASSET_REPO}
+ASSET_FILE=${PACKAGE_DIR}/${PACKAGE}.tar.gz
+ASSET_SUMMARY="${APPLICATION_SUMMARY}"
+ASSET_DESCRIPTION="https://github.com/${GITHUB_REPOSITORY}"
+
+# Build application installation
+echo -e "\e[34mBuilding ${APPLICATION_NAME}...\e[0m"
+make install prefix="${BUILD_DIR}" arch=${PROCESSOR} \
+  version="${APPLICATION_VERSION}"
+
+# Package it all up
+echo -e "\e[34mCreating .tar.gz of ${APPLICATION_NAME}...\e[0m"
+pushd "${BUILD_PREFIX}" || exit 1
+tar -cvzf "${ASSET_FILE}" -- *
+popd || exit 1
+
+# Ship it off to cloudsmith
+echo -e "\e[34mUploading package to cloudsmith...\e[0m"
+cloudsmith push raw --version "${CLOUDSMITH_VERSION}" \
+  --api-key "${CLOUDSMITH_API_KEY}" --summary "${ASSET_SUMMARY}" \
+  --description "${ASSET_DESCRIPTION}" ${ASSET_PATH} "${ASSET_FILE}"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,6 +21,21 @@ task:
     - export PATH="$HOME/.local/share/ponyup/bin/:$PATH"
     - gmake test
 
+task:
+  only_if: $CIRRUS_PR != ''
+
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-xcode:13.3.1
+
+  name: "PR: arm64-apple-darwin"
+
+  install_script:
+    - bash .ci-scripts/MacOS-arm64-install-pony-tools.bash release
+
+  test_script:
+    - export PATH="/tmp/ponyc/bin/:$PATH"
+    - make test
+
 #
 # Nightly build tasks
 #
@@ -49,6 +64,25 @@ task:
     - export PATH="$HOME/.local/share/ponyup/bin/:$PATH"
     - bash .ci-scripts/release/x86-64-unknown-freebsd-13.0-nightly.bash release
 
+task:
+  only_if: $CIRRUS_CRON == "nightly"
+
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-xcode:13.3.1
+
+  name: "nightly: arm64-apple-darwin"
+
+  environment:
+    CLOUDSMITH_API_KEY: ENCRYPTED[fd6a633b6b830c0558d7553d2b1e899b48a47f82037c764ac15febb69a49a53e7415573562f89675ecca9d4e8d6c4969]
+    GITHUB_REPOSITORY: ponylang/corral
+
+  install_script:
+    - bash .ci-scripts/MacOS-arm64-install-pony-tools.bash release
+
+  nightly_script:
+    - export PATH="/tmp/ponyc/bin/:$PATH"
+    - bash .ci-scripts/release/arm64-apple-darwin-nightly.bash
+
 #
 # Release build tasks
 #
@@ -76,3 +110,4 @@ task:
   release_script:
     - export PATH="$HOME/.local/share/ponyup/bin/:$PATH"
     - bash .ci-scripts/release/x86-64-unknown-freebsd-13.0-release.bash
+


### PR DESCRIPTION
We don't need the PR check here except to validate that the installation
process for ponyc works. I'll remove the PR step once we are fully up
and running and using ponyup.