### PR TITLE
Update Dockerfile to use Alpine 3.16 as base

### DIFF
--- a/.release-notes/alpine-316.md
+++ b/.release-notes/alpine-316.md
@@ -1,0 +1,3 @@
+## Update Dockerfile to use Alpine 3.16 as base
+
+The corral Dockerfile has been updated to use Alpine 3.16 as its base image. Previously we were using Alpine 3.12 which is no longer supported. 3.16 is supported until 2024.

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /src/corral
 RUN make arch=x86-64 static=true linker=bfd \
  && make install
 
-FROM alpine:3.12
+FROM alpine:3.16
 
 COPY --from=build /usr/local/bin/corral /usr/local/bin/corral
 


### PR DESCRIPTION
Previously we were using 3.12 which is no longer supported.