### PR TITLE
Only run unit tests when doing breakage tests against new ponyc nightlies

### DIFF
--- a/.github/workflows/breakage-against-macOS-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-macOS-ponyc-latest.yml
@@ -1,19 +1,23 @@
-name: ponyc update breakage test
+name: macOS ponyc update breakage test
 
 on:
   repository_dispatch:
-    types: [shared-docker-linux-builders-updated]
+    types: [ponyc-macos-nightly-released]
 
 jobs:
-  linux:
-    name: Verify main against the latest ponyc on Linux
-    runs-on: ubuntu-latest
-    container:
-      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder:latest
+  macos:
+    name: Verify main against the latest ponyc on macOS
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Test
-        run: make unit-tests config=debug
+      - name: install ponyc
+        run: bash .ci-scripts/macOS-install-pony-tools.bash nightly
+      - name: brew install dependencies
+        run: brew install coreutils
+      - name: Test with most recent ponyc release
+        run: |
+          export PATH="$HOME/.local/share/ponyup/bin/:$PATH"
+          make unit-tests
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip@35d7ad8e98444f894dcfe1d4e17332581d28ebeb

--- a/.github/workflows/breakage-against-windows-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-windows-ponyc-latest.yml
@@ -15,7 +15,7 @@ jobs:
           Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
-          .\make.ps1 -Command test 2>&1
+          .\make.ps1 -Command unit-tests 2>&1
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip@35d7ad8e98444f894dcfe1d4e17332581d28ebeb

--- a/make.ps1
+++ b/make.ps1
@@ -140,6 +140,25 @@ switch ($Command.ToLower())
     break
   }
 
+  "unit-tests"
+  {
+    BuildCorral
+    $testFile = (BuildTest)[-1]
+
+    & "$testFile" --exclude=integration --sequential
+    break
+  }
+
+  "integration-tests"
+  {
+    BuildCorral
+    $testFile = (BuildTest)[-1]
+
+    $env:CORRAL_BIN = Join-Path -Path $buildDir -ChildPath "corral.exe"
+    & "$testFile" --only=integration --sequential
+    break
+  }
+
   "clean"
   {
     if (Test-Path "$buildDir")


### PR DESCRIPTION
The integration tests are likely to spuriously fail due to GitHub issues. The unit tests give us the breakage coverage that we really need and won't spuriously fail. This lack of a chance to fail "randomly" means we won't be training people to ignore breakage test failures.