### PR TITLE
Stop pushing new images to DockerHub

### DIFF
--- a/.ci-scripts/release/build-docker-images-on-release.bash
+++ b/.ci-scripts/release/build-docker-images-on-release.bash
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-# *** You should already be logged in to DockerHub when you run this ***
+# *** You should already be logged in to GitHub Container Registry when you run
+#     this ***
 #
 # Builds docker release images with two tags:
 #
@@ -51,19 +52,6 @@ set -o nounset
 # Tag ref version: "refs/tags/1.0.0"
 # Version: "1.0.0"
 VERSION="${GITHUB_REF/refs\/tags\//}"
-
-## DockerHub
-
-NAME="${GITHUB_REPOSITORY}"
-# Build and push :VERSION tag e.g. ponylang/ponyup:0.32.1
-DOCKER_TAG="${NAME}:${VERSION}"
-docker build --pull -t "${DOCKER_TAG}" .
-docker push "${DOCKER_TAG}"
-
-# Build and push "release" tag e.g. ponylang/ponyup:release
-DOCKER_TAG="${NAME}:release"
-docker build --pull -t "${DOCKER_TAG}" .
-docker push "${DOCKER_TAG}"
 
 ## GitHub Container Registry
 

--- a/.ci-scripts/release/build-latest-docker-images.bash
+++ b/.ci-scripts/release/build-latest-docker-images.bash
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-# *** You should already be logged in to DockerHub when you run this ***
+# *** You should already be logged in to GitHub Container Registry when you run
+#     this ***
 #
 # Builds docker latest docker images.
 #
@@ -32,14 +33,6 @@ fi
 # no unset variables allowed from here on out
 # allow above so we can display nice error messages for expected unset variables
 set -o nounset
-
-## DockerHub
-
-NAME="${GITHUB_REPOSITORY}"
-# Build and push "latest" tag e.g. ponylang/ponyup:latest
-DOCKER_TAG="${NAME}:latest"
-docker build --pull -t "${DOCKER_TAG}" .
-docker push "${DOCKER_TAG}"
 
 ## GitHub Container Registry
 

--- a/.github/workflows/latest-docker-image.yml
+++ b/.github/workflows/latest-docker-image.yml
@@ -15,11 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Login to DockerHub
-        run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,11 +86,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Login to DockerHub
-        run: docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       - name: Login to GitHub Container Registry
         # v2.2.0
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc


### PR DESCRIPTION
We've migrated off of DockerHub and all new images are stored only in the GitHub Container Registry.