### PR TITLE
Use release ponyc version for Apple Silicon MacOS releases

### DIFF
--- a/.ci-scripts/macos-arm64-install-pony-tools.bash
+++ b/.ci-scripts/macos-arm64-install-pony-tools.bash
@@ -2,7 +2,7 @@
 
 case "${1}" in
 "release")
-  REPO=release
+  REPO=releases
   ;;
 "nightly")
   REPO=nightlies

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -82,7 +82,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: install ponyc
-        run: bash .ci-scripts/macos-arm64-install-pony-tools.bash nightly
+        run: bash .ci-scripts/macos-arm64-install-pony-tools.bash release
       - name: brew install dependencies
         run: brew install coreutils
       - name: Test with most recent ponyc release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: install ponyc
-        run: bash .ci-scripts/macos-arm64-install-pony-tools.bash nightly
+        run: bash .ci-scripts/macos-arm64-install-pony-tools.bash release
       - name: brew install dependencies
         run: brew install coreutils
       - name: pip install dependencies


### PR DESCRIPTION
We were using nightlies as we had no recent ponyc releases until 0.58.2 went out today.