### PR TITLE
Fix bug with default bundle directory handling

### DIFF
--- a/.release-notes/275.md
+++ b/.release-notes/275.md
@@ -1,0 +1,5 @@
+## Fix bug with default bundle directory handling
+
+There was a bug in corral's handling of the the `-d` command line option. The default value was set to the string "<cwd>". This would result in corral.json not being found.
+
+The bug wasn't triggered because a bug in the Pony standard library prevented the default value from correctly being applied. Once that bug was fixed, corral stopped working unless a `-d` value was provided.

--- a/corral/cli.pony
+++ b/corral/cli.pony
@@ -47,9 +47,9 @@ primitive CLI
           default' = false)
         OptionSpec.string(
           "bundle_dir",
-          "The directory where the bundle's corral.json and lock.json are located."
+          "The directory where the bundle's corral.json and lock.json are located. Defaults to the current working directory."
           where short' = 'd',
-          default' = "<cwd>")
+          default' = "")
       ],
       [
         CommandSpec.leaf(


### PR DESCRIPTION
There was a bug in corral's handling of the the `-d` command line option. The default value was set to the string "<cwd>". This would result in corral.json not being found.

The bug wasn't triggered because a bug in the Pony standard library prevented the default value from correctly being applied. Once that bug was fixed, corral stopped working unless a `-d` value was provided.