### PR TITLE
Disable Windows Defender in CI

### DIFF
--- a/.github/workflows/breakage-against-windows-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-windows-ponyc-latest.yml
@@ -12,6 +12,8 @@ jobs:
     name: Verify main against the latest ponyc on Windows
     runs-on: windows-2025
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Test with most recent ponyc nightly
         run: |

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -73,6 +73,8 @@ jobs:
     name: Build and upload x86-64-pc-windows-msvc-nightly to Cloudsmith
     runs-on: windows-2025
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Build and upload
         run: |
@@ -103,6 +105,8 @@ jobs:
     name: Build and upload arm64-pc-windows-msvc-nightly to Cloudsmith
     runs-on: windows-11-arm
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Build and upload
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -56,6 +56,8 @@ jobs:
     name: x86_64 Windows
     runs-on: windows-2025
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Test with most recent ponyc release
         run: |
@@ -68,6 +70,8 @@ jobs:
     name: arm64 Windows
     runs-on: windows-11-arm
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Test with most recent ponyc release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,8 @@ jobs:
     needs:
       - pre-artefact-creation
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Build and upload
         run: |
@@ -138,6 +140,8 @@ jobs:
     needs:
       - pre-artefact-creation
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Build and upload
         run: |


### PR DESCRIPTION
Disable Windows Defender real-time monitoring as the first step in all Windows CI jobs.