### PR TITLE
Replace brittle stdout checks in integration tests

### DIFF
--- a/corral/cmd/_test_cmd_update.pony
+++ b/corral/cmd/_test_cmd_update.pony
@@ -11,6 +11,7 @@ actor _TestCmdUpdate is TestList
 
   fun tag tests(test: PonyTest) =>
     test(_TestEmptyDeps)
+    test(_TestLocalDirect)
     test(_TestMutuallyRecursive)
     test(_TestRegression120)
     test(_TestSelfReferential)
@@ -29,6 +30,21 @@ class iso _TestEmptyDeps is UnitTest
       h,
       "empty-deps",
       _OpsRecorder(h, 0, 0, 0))?
+
+class iso _TestLocalDirect is UnitTest
+  """
+  Verify that a bundle with a single local dependency executes exactly
+  1 sync, 1 tag query, and 1 checkout operation.
+  """
+
+  fun name(): String =>
+    "cmd/update/" + __loc.type_name()
+
+  fun apply(h: TestHelper) ? =>
+    _OpsRecorderTestRunner(
+      h,
+      "local-direct",
+      _OpsRecorder(h, 1, 1, 1))?
 
 class iso _TestMutuallyRecursive is UnitTest
   """

--- a/corral/test/integration/test_help.pony
+++ b/corral/test/integration/test_help.pony
@@ -10,8 +10,5 @@ class  \nodoc\ TestHelp is UnitTest
       recover ["help"] end,
       {(h: TestHelper, ar: ActionResult) =>
         h.assert_eq[I32](0, ar.exit_code())
-        h.assert_true(ar.stdout.contains("usage:"))
-        h.assert_true(ar.stdout.contains("Options:"))
-        h.assert_true(ar.stdout.contains("Commands:"))
         h.complete(ar.exit_code() == 0)
       })

--- a/corral/test/integration/test_info.pony
+++ b/corral/test/integration/test_info.pony
@@ -1,4 +1,3 @@
-use "files"
 use "pony_test"
 use ".."
 use "../../util"
@@ -14,12 +13,6 @@ class  \nodoc\ TestInfo is UnitTest
       ] end,
       {(h: TestHelper, ar: ActionResult) =>
         h.assert_eq[I32](0, ar.exit_code())
-        h.assert_true(ar.stdout.contains("info: {"))
-        h.assert_true(ar.stdout.contains("\"description\":\"\""))
-        h.assert_true(ar.stdout.contains("\"homepage\":\"\""))
-        h.assert_true(ar.stdout.contains("\"license\":\"\""))
-        h.assert_true(ar.stdout.contains("\"version\":\"\""))
-        h.assert_true(ar.stdout.contains("\"name\":\"\""))
         h.complete(ar.exit_code() == 0)
       })
 

--- a/corral/test/integration/test_run.pony
+++ b/corral/test/integration/test_run.pony
@@ -16,7 +16,6 @@ class \nodoc\ TestRun is UnitTest
       ] end,
       {(h: TestHelper, ar: ActionResult) =>
         h.assert_eq[I32](0, ar.exit_code())
-        h.assert_true(ar.stdout.lower().contains("compiled with: "))
         h.complete(ar.exit_code() == 0)
       })
 
@@ -33,7 +32,6 @@ class \nodoc\ TestRunWithoutBundle is UnitTest
       ] end,
       {(h: TestHelper, ar: ActionResult) =>
         h.assert_eq[I32](0, ar.exit_code())
-        h.assert_true(ar.stdout.lower().contains("compiled with: "))
         h.complete(ar.exit_code() == 0)
       })
 
@@ -129,6 +127,5 @@ class \nodoc\ TestRunBinaryInParentFolder is UnitTest
       ] end,
       {(h: TestHelper, ar: ActionResult) =>
         h.assert_eq[I32](0, ar.exit_code())
-        h.assert_true(ar.stdout.lower().contains("compiled with: "))
         h.complete(ar.exit_code() == 0)
       })

--- a/corral/test/integration/test_update.pony
+++ b/corral/test/integration/test_update.pony
@@ -15,7 +15,6 @@ class  \nodoc\ TestUpdateEmpty is UnitTest
       ] end,
       {(h: TestHelper, ar: ActionResult) =>
         h.assert_eq[I32](0, ar.exit_code())
-        h.assert_true(ar.stdout.contains("update:"))
         h.complete(ar.exit_code() == 0)
       })
 
@@ -40,7 +39,6 @@ class  \nodoc\ TestUpdateLocalDirect is UnitTest
       {(h: TestHelper, ar: ActionResult)(data=data) =>
         try
           h.assert_eq[I32](0, ar.exit_code())
-          h.assert_true(ar.stdout.contains("update:"))
 
           let repos_dir = data.dir_path("_repos")?
           h.assert_false(repos_dir.exists())
@@ -74,7 +72,6 @@ class  \nodoc\ TestUpdateMutuallyRecursive is UnitTest
       {(h: TestHelper, ar: ActionResult)(data=data) =>
         try
           h.assert_eq[I32](0, ar.exit_code())
-          h.assert_true(ar.stdout.contains("update:"))
 
           let repos_dir = data.dir_path("_repos")?
           h.assert_false(repos_dir.exists())
@@ -107,7 +104,6 @@ class  \nodoc\ TestUpdateSelfReferential is UnitTest
       {(h: TestHelper, ar: ActionResult)(data=data) =>
         try
           h.assert_eq[I32](0, ar.exit_code())
-          h.assert_true(ar.stdout.contains("update:"))
 
           let repos_dir = data.dir_path("_repos")?
           h.assert_false(repos_dir.exists())
@@ -140,7 +136,6 @@ class  \nodoc\ TestUpdateGithub is UnitTest
       {(h: TestHelper, ar: ActionResult)(data=data) =>
         try
           h.assert_eq[I32](0, ar.exit_code())
-          h.assert_true(ar.stdout.contains("update:"))
 
           // Check that lock was at least created.
           let lock_file = data.dir_path("lock.json")?
@@ -211,7 +206,6 @@ class  \nodoc\ TestUpdateGithubDeep is UnitTest
       {(h: TestHelper, ar: ActionResult)(data=data) =>
         try
           h.assert_eq[I32](0, ar.exit_code())
-          h.assert_true(ar.stdout.contains("update:"))
 
           let repos_dir = data.dir_path("_repos")?
           h.assert_true(repos_dir.join("github_com_ponylang_corral_test_repo_git")?.exists())
@@ -247,7 +241,6 @@ class  \nodoc\ TestUpdateRemoteGits is UnitTest
       {(h: TestHelper, ar: ActionResult)(data=data) =>
         try
           h.assert_eq[I32](0, ar.exit_code())
-          h.assert_true(ar.stdout.contains("update:"))
 
           let repos_dir = data.dir_path("_repos")?
           h.assert_true(repos_dir.join("bitbucket_org_cquinn_pony_thing_git")?.exists())

--- a/corral/test/integration/test_version.pony
+++ b/corral/test/integration/test_version.pony
@@ -1,6 +1,5 @@
 use "pony_test"
 use ".."
-use "../.."
 use "../../util"
 
 class  \nodoc\ TestVersion is UnitTest
@@ -12,6 +11,4 @@ class  \nodoc\ TestVersion is UnitTest
 class  \nodoc\ CheckVersion is Checker
   fun tag apply(h: TestHelper, ar: ActionResult) =>
     h.assert_eq[I32](0, ar.exit_code())
-    h.assert_true(ar.stdout.at("version: "))
-    h.assert_true(ar.stdout.at(Version(), 9))
     h.complete(ar.exit_code() == 0)


### PR DESCRIPTION
## Context

Several integration tests verify behavior by checking for specific strings in stdout output. This couples the tests to logging verbosity and output formatting, causing them to break whenever those details change (as happened in #137).

## Changes

- Remove `stdout.contains("update:")` assertions from 7 update integration tests; exit code and filesystem checks provide sufficient coverage
- Remove stdout assertions from `integration/help`, `integration/info`, `integration/version`, `integration/run`, `integration/run/without-bundle`, and `integration/run/binary-in-parent-folder`; reduce these to exit code checks
- Add `_TestLocalDirect` unit test using `_RecordedVCS` test-double to verify operation counts for a single local dependency, following the pattern established in #132 and #134

Resolves #138

## Considerations

Not all stdout checks are problematic. The remaining assertions in `test_run.pony` and `test_update.pony` are intentional and should be preserved:

- **Error path tests** (`no-args`, `binary-not-found`, `binary-not-found-absolute`) verify that corral emits specific, user-facing error messages. These strings are part of the observable contract of the command, not incidental log output.
- **Quiet mode test** (`run/quiet`) verifies that corral suppresses its own logging when `--quiet` is passed. The negative stdout assertions are the only way to confirm suppression is working.
- **Script execution test** (`update/scripts`) verifies that post-fetch scripts are actually run. The script's stdout output is the behavior under test, not a log message from corral itself.

The distinction is: if the stdout content *is* the feature, keep the assertion. If stdout is only being checked as a proxy for whether a command succeeded, replace it.