### PR TITLE
Revert macOS Intel runner to macos-15-intel

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,4 +2,4 @@
 self-hosted-runner:
   labels:
     - windows-11-arm
-    - macos-26-intel
+    - macos-15-intel

--- a/.github/workflows/breakage-against-macos-x86-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-macos-x86-ponyc-latest.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   macos:
     name: Verify main against the latest ponyc on macOS
-    runs-on: macos-26-intel
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install ponyc

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -135,7 +135,7 @@ jobs:
 
   x86-64-apple-darwin-nightly:
     name: Build and upload x86-64-apple-darwin-nightly to Cloudsmith
-    runs-on: macos-26-intel
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install ponyc

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -82,7 +82,7 @@ jobs:
 
   x86_macos:
     name: x86_64 MacOS
-    runs-on: macos-26-intel
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install ponyc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
 
   x86-64-apple-darwin-release:
     name: Build and upload x86-64-apple-darwin-release to Cloudsmith
-    runs-on: macos-26-intel
+    runs-on: macos-15-intel
     needs:
       - pre-artefact-creation
     steps:


### PR DESCRIPTION
The macos-26-intel runners are highly unstable. Reverting to macos-15-intel until the instability is resolved.