### PR TITLE
Publish release binaries to GitHub Releases in addition to Cloudsmith

### DIFF
--- a/.ci-scripts/release/arm64-apple-darwin-release.bash
+++ b/.ci-scripts/release/arm64-apple-darwin-release.bash
@@ -3,7 +3,7 @@
 # x86-64-unknown-linux release:
 #
 # - Builds release package
-# - Uploads to Cloudsmith
+# - Uploads to Cloudsmith and to the GitHub Release
 #
 # Tools required in the environment that runs this:
 #
@@ -12,6 +12,7 @@
 # - GNU gzip
 # - GNU make
 # - ponyc
+# - python3
 # - GNU tar
 
 set -o errexit
@@ -27,6 +28,12 @@ source "${base}/config.bash"
 # provide all of these if properly configured
 if [[ -z "${CLOUDSMITH_API_KEY}" ]]; then
   echo -e "\e[31mCloudsmith API key needs to be set in CLOUDSMITH_API_KEY."
+  echo -e "Exiting.\e[0m"
+  exit 1
+fi
+
+if [[ -z "${RELEASE_TOKEN}" ]]; then
+  echo -e "\e[31mRELEASE_TOKEN needs to be set for the GitHub Release upload."
   echo -e "Exiting.\e[0m"
   exit 1
 fi
@@ -99,3 +106,6 @@ echo -e "\e[34mUploading package to cloudsmith...\e[0m"
 cloudsmith push raw --version "${CLOUDSMITH_VERSION}" \
   --api-key "${CLOUDSMITH_API_KEY}" --summary "${ASSET_SUMMARY}" \
   --description "${ASSET_DESCRIPTION}" ${ASSET_PATH} "${ASSET_FILE}"
+
+echo -e "\e[34mUploading package to GitHub Release...\e[0m"
+python3 "${base}/github_release.py" upload "${APPLICATION_VERSION}" "${ASSET_FILE}"

--- a/.ci-scripts/release/arm64-unknown-linux-release.bash
+++ b/.ci-scripts/release/arm64-unknown-linux-release.bash
@@ -3,7 +3,7 @@
 # arm64-unknown-linux release:
 #
 # - Builds release package
-# - Uploads to Cloudsmith
+# - Uploads to Cloudsmith and to the GitHub Release
 #
 # Tools required in the environment that runs this:
 #
@@ -12,6 +12,7 @@
 # - GNU gzip
 # - GNU make
 # - ponyc (musl based version)
+# - python3
 # - GNU tar
 
 set -o errexit
@@ -27,6 +28,12 @@ source "${base}/config.bash"
 # provide all of these if properly configured
 if [[ -z "${CLOUDSMITH_API_KEY}" ]]; then
   echo -e "\e[31mCloudsmith API key needs to be set in CLOUDSMITH_API_KEY."
+  echo -e "Exiting.\e[0m"
+  exit 1
+fi
+
+if [[ -z "${RELEASE_TOKEN}" ]]; then
+  echo -e "\e[31mRELEASE_TOKEN needs to be set for the GitHub Release upload."
   echo -e "Exiting.\e[0m"
   exit 1
 fi
@@ -99,3 +106,6 @@ echo -e "\e[34mUploading package to cloudsmith...\e[0m"
 cloudsmith push raw --version "${CLOUDSMITH_VERSION}" \
   --api-key "${CLOUDSMITH_API_KEY}" --summary "${ASSET_SUMMARY}" \
   --description "${ASSET_DESCRIPTION}" ${ASSET_PATH} "${ASSET_FILE}"
+
+echo -e "\e[34mUploading package to GitHub Release...\e[0m"
+python3 "${base}/github_release.py" upload "${APPLICATION_VERSION}" "${ASSET_FILE}"

--- a/.ci-scripts/release/github_release.py
+++ b/.ci-scripts/release/github_release.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Upload corral release archives to a GitHub Release.
+
+Stdlib only so no pip install is required on any CI runner.
+"""
+
+import hashlib
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+ENDC = '\033[0m'
+ERROR = '\033[31m'
+INFO = '\033[34m'
+
+API_VERSION = '2022-11-28'
+API_BASE = 'https://api.github.com'
+UPLOAD_BASE = 'https://uploads.github.com'
+REQUEST_TIMEOUT = 300
+
+
+def die(message):
+    print(ERROR + message + ENDC, file=sys.stderr)
+    sys.exit(1)
+
+
+def require_env(name):
+    value = os.environ.get(name, '')
+    if not value:
+        die(f"{name} needs to be set in env. Exiting.")
+    return value
+
+
+def auth_headers(token):
+    return {
+        'Authorization': f'Bearer {token}',
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': API_VERSION,
+    }
+
+
+def api_request(method, url, token, data=None, content_type=None):
+    headers = auth_headers(token)
+    if content_type is not None:
+        headers['Content-Type'] = content_type
+    request = urllib.request.Request(url, data=data, headers=headers,
+                                     method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT) as r:
+            return r.status, r.read()
+    except urllib.error.HTTPError as e:
+        body = e.read().decode('utf-8', errors='replace')
+        die(f"GitHub API {method} {url} failed: {e.code}\n{body}")
+    except (urllib.error.URLError, OSError) as e:
+        die(f"GitHub API {method} {url} failed: {e}")
+
+
+def get_release(repo, tag, token):
+    tag_q = urllib.parse.quote(tag, safe='')
+    url = f'{API_BASE}/repos/{repo}/releases/tags/{tag_q}'
+    _, body = api_request('GET', url, token)
+    return json.loads(body)
+
+
+def delete_asset(repo, asset_id, token):
+    url = f'{API_BASE}/repos/{repo}/releases/assets/{asset_id}'
+    api_request('DELETE', url, token)
+
+
+def upload_asset(repo, release_id, path, token):
+    name = os.path.basename(path)
+    query = urllib.parse.urlencode({'name': name})
+    url = (f'{UPLOAD_BASE}/repos/{repo}/releases/{release_id}/assets'
+           f'?{query}')
+    with open(path, 'rb') as f:
+        data = f.read()
+    api_request('POST', url, token, data=data,
+                content_type='application/octet-stream')
+
+
+def write_sha512_sibling(archive_path):
+    # Raw hex + newline. NOT sha512sum CLI format (which appends "  <filename>");
+    # consumers read the whole file as the hex digest. See migration design in
+    # https://github.com/ponylang/ponyup/discussions/405.
+    h = hashlib.sha512()
+    with open(archive_path, 'rb') as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b''):
+            h.update(chunk)
+    sibling_path = archive_path + '.sha512'
+    with open(sibling_path, 'w') as f:
+        f.write(h.hexdigest() + '\n')
+    return sibling_path
+
+
+def cmd_upload(tag, path):
+    token = require_env('RELEASE_TOKEN')
+    repo = require_env('GITHUB_REPOSITORY')
+
+    if not os.path.isfile(path):
+        die(f"File not found: {path}")
+
+    print(INFO + f"Writing SHA-512 sibling for {os.path.basename(path)}..."
+          + ENDC)
+    sibling_path = write_sha512_sibling(path)
+    upload_paths = [path, sibling_path]
+    upload_names = {os.path.basename(p) for p in upload_paths}
+
+    print(INFO + f"Fetching release {tag}..." + ENDC)
+    release = get_release(repo, tag, token)
+    release_id = release['id']
+
+    # Clobber any prior upload of the archive or its sibling so restarts
+    # converge. A DELETE that succeeds followed by a POST that fails leaves
+    # the release missing the asset; re-pushing the X.Y.Z tag re-runs this
+    # script and reconverges. Delete every matching-name asset rather than
+    # stopping at the first — the Releases API does not guarantee name
+    # uniqueness across assets.
+    for asset in release.get('assets', []):
+        if asset.get('name') in upload_names:
+            print(INFO + f"Deleting existing asset {asset['name']}..." + ENDC)
+            delete_asset(repo, asset['id'], token)
+
+    for upload_path in upload_paths:
+        name = os.path.basename(upload_path)
+        print(INFO + f"Uploading {name} to release {tag}..." + ENDC)
+        upload_asset(repo, release_id, upload_path, token)
+    print(INFO + "Upload complete." + ENDC)
+
+
+def usage():
+    die("usage: github_release.py upload <tag> <file>")
+
+
+def main(argv):
+    if len(argv) < 2:
+        usage()
+    command = argv[1]
+    if command == 'upload':
+        if len(argv) != 4:
+            usage()
+        cmd_upload(argv[2], argv[3])
+    else:
+        usage()
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/.ci-scripts/release/x86-64-apple-darwin-release.bash
+++ b/.ci-scripts/release/x86-64-apple-darwin-release.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # - Builds release package
-# - Uploads to Cloudsmith
+# - Uploads to Cloudsmith and to the GitHub Release
 #
 # Tools required in the environment that runs this:
 #
@@ -10,6 +10,7 @@
 # - GNU gzip
 # - GNU make
 # - ponyc
+# - python3
 # - GNU tar
 
 set -o errexit
@@ -25,6 +26,12 @@ source "${base}/config.bash"
 # provide all of these if properly configured
 if [[ -z "${CLOUDSMITH_API_KEY}" ]]; then
   echo -e "\e[31mCloudsmith API key needs to be set in CLOUDSMITH_API_KEY."
+  echo -e "Exiting.\e[0m"
+  exit 1
+fi
+
+if [[ -z "${RELEASE_TOKEN}" ]]; then
+  echo -e "\e[31mRELEASE_TOKEN needs to be set for the GitHub Release upload."
   echo -e "Exiting.\e[0m"
   exit 1
 fi
@@ -96,3 +103,6 @@ echo -e "\e[34mUploading package to cloudsmith...\e[0m"
 cloudsmith push raw --version "${CLOUDSMITH_VERSION}" \
   --api-key "${CLOUDSMITH_API_KEY}" --summary "${ASSET_SUMMARY}" \
   --description "${ASSET_DESCRIPTION}" ${ASSET_PATH} "${ASSET_FILE}"
+
+echo -e "\e[34mUploading package to GitHub Release...\e[0m"
+python3 "${base}/github_release.py" upload "${APPLICATION_VERSION}" "${ASSET_FILE}"

--- a/.ci-scripts/release/x86-64-unknown-linux-release.bash
+++ b/.ci-scripts/release/x86-64-unknown-linux-release.bash
@@ -3,7 +3,7 @@
 # x86-64-unknown-linux release:
 #
 # - Builds release package
-# - Uploads to Cloudsmith
+# - Uploads to Cloudsmith and to the GitHub Release
 #
 # Tools required in the environment that runs this:
 #
@@ -12,6 +12,7 @@
 # - GNU gzip
 # - GNU make
 # - ponyc (musl based version)
+# - python3
 # - GNU tar
 
 set -o errexit
@@ -27,6 +28,12 @@ source "${base}/config.bash"
 # provide all of these if properly configured
 if [[ -z "${CLOUDSMITH_API_KEY}" ]]; then
   echo -e "\e[31mCloudsmith API key needs to be set in CLOUDSMITH_API_KEY."
+  echo -e "Exiting.\e[0m"
+  exit 1
+fi
+
+if [[ -z "${RELEASE_TOKEN}" ]]; then
+  echo -e "\e[31mRELEASE_TOKEN needs to be set for the GitHub Release upload."
   echo -e "Exiting.\e[0m"
   exit 1
 fi
@@ -98,3 +105,6 @@ echo -e "\e[34mUploading package to cloudsmith...\e[0m"
 cloudsmith push raw --version "${CLOUDSMITH_VERSION}" \
   --api-key "${CLOUDSMITH_API_KEY}" --summary "${ASSET_SUMMARY}" \
   --description "${ASSET_DESCRIPTION}" ${ASSET_PATH} "${ASSET_FILE}"
+
+echo -e "\e[34mUploading package to GitHub Release...\e[0m"
+python3 "${base}/github_release.py" upload "${APPLICATION_VERSION}" "${ASSET_FILE}"

--- a/.github/workflows/announce-a-release.yml
+++ b/.github/workflows/announce-a-release.yml
@@ -20,21 +20,31 @@ jobs:
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
+      # By the time this step runs, release.yml has already created the
+      # GitHub Release for this version and attached the platform archives
+      # as assets. publish-release-notes-to-github must update the existing
+      # release rather than replace it; replacing would drop those assets.
+      # The update fills in the body and sets `make_latest=legacy`, which
+      # tells GitHub to recompute the "Latest" designation from creation
+      # date + semver across all releases. For the normal release flow
+      # (newest release, highest semver) that reselects this release as
+      # "Latest"; the empty-body window created by release.yml was marked
+      # `make_latest=false` so it never held that designation.
       - name: Release notes
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.6
         with:
           entrypoint: publish-release-notes-to-github
         env:
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       - name: Zulip
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.6
         with:
           entrypoint: send-announcement-to-pony-zulip
         env:
           ZULIP_API_KEY: ${{ secrets.ZULIP_RELEASE_API_KEY }}
           ZULIP_EMAIL: ${{ secrets.ZULIP_RELEASE_EMAIL }}
       - name: Last Week in Pony
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.6
         with:
           entrypoint: add-announcement-to-last-week-in-pony
         env:
@@ -52,14 +62,14 @@ jobs:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Rotate release notes
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.6
         with:
           entrypoint: rotate-release-notes
         env:
           GIT_USER_NAME: "Ponylang Main Bot"
           GIT_USER_EMAIL: "ponylang.main@gmail.com"
       - name: Delete announcement trigger tag
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.6
         with:
           entrypoint: delete-announcement-tag
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,20 @@ jobs:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Validate CHANGELOG
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.6
         with:
           entrypoint: pre-artefact-changelog-check
+      # Create the GitHub Release now with an empty body so each platform job
+      # can attach its archive as an asset. announce-a-release.yml will later
+      # populate the body and mark the release as "latest" via
+      # publish-release-notes-to-github, which updates (rather than replaces)
+      # the release and therefore leaves the assets intact.
+      - name: Create GitHub release (empty body; announce fills it)
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.6
+        with:
+          entrypoint: create-empty-github-release
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
   # Currently, GitHub actions supplied by GH like checkout and cache do not work
   # in musl libc environments on arm64. We can work around this by running
@@ -39,7 +50,7 @@ jobs:
   # container" but is required to work around the GitHub actions limitation
   # documented above.
   arm64-unknown-linux-release:
-    name: Build and upload arm64-unknown-linux-release to Cloudsmith
+    name: Build and upload arm64-unknown-linux-release
     runs-on: ubuntu-24.04-arm
     needs:
       - pre-artefact-creation
@@ -54,12 +65,13 @@ jobs:
             -v ${{ github.workspace }}:/root/project \
             -w /root/project \
             -e CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }} \
+            -e RELEASE_TOKEN=${{ secrets.RELEASE_TOKEN }} \
             -e GITHUB_REPOSITORY=${{ github.repository }} \
             ghcr.io/ponylang/shared-docker-ci-standard-builder:release \
             bash .ci-scripts/release/arm64-unknown-linux-release.bash
 
   x86-64-unknown-linux-release:
-    name: Build and upload x86-64-unknown-linux-release to Cloudsmith
+    name: Build and upload x86-64-unknown-linux-release
     runs-on: ubuntu-latest
     needs:
       - pre-artefact-creation
@@ -71,9 +83,11 @@ jobs:
         run: bash .ci-scripts/release/x86-64-unknown-linux-release.bash
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
 
   x86-64-apple-darwin-release:
-    name: Build and upload x86-64-apple-darwin-release to Cloudsmith
+    name: Build and upload x86-64-apple-darwin-release
     runs-on: macos-15-intel
     needs:
       - pre-artefact-creation
@@ -91,9 +105,11 @@ jobs:
           bash .ci-scripts/release/x86-64-apple-darwin-release.bash
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
 
   arm64-apple-darwin-release:
-    name: Build and upload arm64-apple-darwin-release to Cloudsmith
+    name: Build and upload arm64-apple-darwin-release
     runs-on: macos-26
     needs:
       - pre-artefact-creation
@@ -111,9 +127,11 @@ jobs:
           bash .ci-scripts/release/arm64-apple-darwin-release.bash
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
 
   x86-64-pc-windows-msvc-release:
-    name: Build and upload x86-64-pc-windows-msvc-release to Cloudsmith
+    name: Build and upload x86-64-pc-windows-msvc-release
     runs-on: windows-2025
     needs:
       - pre-artefact-creation
@@ -131,11 +149,15 @@ jobs:
           .\make.ps1 -Command install;
           .\make.ps1 -Command package;
           $version = (Get-Content .\VERSION); cloudsmith push raw --version $version --api-key $env:CLOUDSMITH_API_KEY --summary "Pony dependency manager tool" --description "https://github.com/ponylang/corral" ponylang/releases build\corral-x86-64-pc-windows-msvc.zip
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          python .ci-scripts\release\github_release.py upload $version build\corral-x86-64-pc-windows-msvc.zip
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
 
   arm64-pc-windows-msvc-release:
-    name: Build and upload arm64-pc-windows-msvc-release to Cloudsmith
+    name: Build and upload arm64-pc-windows-msvc-release
     runs-on: windows-11-arm
     needs:
       - pre-artefact-creation
@@ -153,8 +175,12 @@ jobs:
           .\make.ps1 -Command install;
           .\make.ps1 -Command package;
           $version = (Get-Content .\VERSION); cloudsmith push raw --version $version --api-key $env:CLOUDSMITH_API_KEY --summary "Pony dependency manager tool" --description "https://github.com/ponylang/corral" ponylang/releases build\corral-arm64-pc-windows-msvc.zip
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          python .ci-scripts\release\github_release.py upload $version build\corral-arm64-pc-windows-msvc.zip
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
 
   generate-documentation:
     name: Generate documentation for release
@@ -178,6 +204,8 @@ jobs:
     name: Trigger release announcement
     runs-on: ubuntu-latest
     needs:
+      - arm64-pc-windows-msvc-release
+      - arm64-unknown-linux-release
       - x86-64-unknown-linux-release
       - x86-64-pc-windows-msvc-release
       - x86-64-apple-darwin-release
@@ -189,7 +217,7 @@ jobs:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Trigger
-        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.5
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.6
         with:
           entrypoint: trigger-release-announcement
         env:

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -32,7 +32,9 @@ As documented above, a release is started by pushing a tag of the form `release-
 
 ## Build artifacts
 
-The release process can be manually restarted from here by pushing a tag of the form `x.y.z`. The pushed tag must be on the commit to build the release artifacts from. During the normal process, that commit is the same as the one that `release-x.y.z`.
+Each platform job builds a release archive and publishes it to two destinations: the Cloudsmith `ponylang/releases` repository and the GitHub Release at tag `x.y.z`. The GitHub Release itself is created early in this stage with an empty body; the `Announce release` stage fills in the body and marks the release as "latest."
+
+The release process can be manually restarted from here by pushing a tag of the form `x.y.z`. The pushed tag must be on the commit to build the release artifacts from. During the normal process, that commit is the same as the one that `release-x.y.z` was pushed on. Re-pushing `x.y.z` is safe: the GitHub Release is left in place if it already exists, and each platform job re-uploads its archive, replacing any prior copy.
 
 ## Announce release
 


### PR DESCRIPTION
Downstream consumers of corral (and future ponylang tooling) want a GitHub-Release-based channel for release binaries so they aren't coupled to the Cloudsmith URL scheme. This change attaches every platform archive to the GitHub Release at the version tag alongside the existing Cloudsmith upload, and writes a `.sha512` sibling for each archive so consumers have a verifiable integrity artifact without an extra API round-trip. Cloudsmith remains the source of truth and is unchanged.

Ports ponylang/ponyup#408 and #409 (plus the intermediate `RELEASE_TOKEN` auth fix) into corral.

Also fixes a pre-existing bug: `trigger-release-announcement`'s `needs:` list omitted `arm64-unknown-linux-release` and `arm64-pc-windows-msvc-release`, so a failure on either job did not block announcement.