### PR TITLE
Write SHA-512 sibling in binary mode for cross-platform byte-identical output

### DIFF
--- a/.ci-scripts/release/github_release.py
+++ b/.ci-scripts/release/github_release.py
@@ -90,8 +90,11 @@ def write_sha512_sibling(archive_path):
         for chunk in iter(lambda: f.read(1024 * 1024), b''):
             h.update(chunk)
     sibling_path = archive_path + '.sha512'
-    with open(sibling_path, 'w') as f:
-        f.write(h.hexdigest() + '\n')
+    # Binary mode: keep the digest file byte-identical across platforms.
+    # Text mode on Windows would rewrite '\n' as '\r\n' and produce Windows
+    # archives with CRLF-terminated siblings while Linux/macOS produce LF.
+    with open(sibling_path, 'wb') as f:
+        f.write((h.hexdigest() + '\n').encode('ascii'))
     return sibling_path
 
 


### PR DESCRIPTION
Python's default text mode on Windows translates `\n` to `\r\n` on write, so Windows-built archives would get CRLF-terminated `.sha512` siblings while Linux and macOS produce LF. The file is meant to be the byte sequence `<hex>\n` and future consumers (see ponylang/ponyup#405) will byte-compare, so the asymmetry is a latent portability bug.

Switches to binary mode with explicit ASCII bytes and adds a short comment explaining why.

Defensive for corral specifically (no Windows release job today), but applied for cross-repo consistency — the same script is duplicated across corral, ponyup, ponyc, and changelog-tool pending centralization. Mirrors the fix in ponylang/ponyc#5233.