### PR TITLE
Update AI assistant onboarding note for contributors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,19 +5,23 @@ Pony dependency manager. Manages `corral.json` (deps/packages/info) and `lock.js
 <!-- contributor-only -->
 ## Contributing with an AI assistant
 
-This is a Pony project. The ponylang org maintains a set of LLM coding skills. If your AI assistant isn't set up with them, install them once:
+This is a Pony project. The ponylang org maintains a set of LLM coding skills. Get set up with them before contributing:
 
-```bash
-git clone https://github.com/ponylang/llm-skills.git
-cd llm-skills
-python install.py
-```
+- **Not set up yet?** Install them once:
+
+  ```bash
+  git clone https://github.com/ponylang/llm-skills.git
+  cd llm-skills
+  python install.py
+  ```
+
+- **Already set up?** Make sure you're on the latest. If you installed with the script above, `git pull` in the directory where you cloned `llm-skills` and the symlinked skills update automatically — if you set them up another way, refresh them however that setup expects.
 
 See the [llm-skills README](https://github.com/ponylang/llm-skills) for details and other harnesses.
 
 When you start working on this project, load the `pony-skills` skill — it tells your assistant which Pony skill to use for each task.
 
-Before opening a pull request, read [CONTRIBUTING.md](CONTRIBUTING.md).
+Read [CONTRIBUTING.md](CONTRIBUTING.md).
 <!-- /contributor-only -->
 
 ## Building and Testing


### PR DESCRIPTION
Updates the contributor-only block in CLAUDE.md: install-vs-update either/or so contributors who already have the ponylang LLM skills are nudged to `git pull` for the latest, plus a blanket pointer to CONTRIBUTING.md.