### PR TITLE
Lint Python scripts in .ci-scripts on every PR

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -1,0 +1,23 @@
+name: Lint Python Scripts
+
+on: pull_request
+
+concurrency:
+  group: lint-python-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  packages: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Check Python files under .ci-scripts/
+        # ruff 0.15.12
+        uses: docker://ghcr.io/astral-sh/ruff@sha256:e42f3866bb9f701dbc459cdec3f5aca06511e6a38e6e04bfd4d04a2be26d4fd4
+        with:
+          args: check .ci-scripts


### PR DESCRIPTION
The `.ci-scripts/release/` Python scripts (`github_release.py`, `ghcr_nightly.py`) run only during release and nightly workflows. A syntax error, undefined name, or stale import there breaks a release while a git tag is already pushed.

This adds a `pull_request`-triggered job that runs the pinned ruff Docker image (ruff 0.15.12) against `.ci-scripts`, mirroring ponyup's `lint-python.yml`. Modeled on ponyup, it uses ruff's default rules with no config file. Verified locally that the existing scripts pass with the same pinned image.

Closes #324
Closes #316