### PR TITLE
Move Windows CI to the windows-2025-vs2026 runner

### DIFF
--- a/.github/workflows/breakage-against-windows-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-windows-ponyc-latest.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   windows:
     name: Verify main against the latest ponyc on Windows
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     steps:
       - name: Disable Windows Defender
         run: Set-MpPreference -DisableRealtimeMonitoring $true

--- a/.github/workflows/lint-action-workflows.yml
+++ b/.github/workflows/lint-action-workflows.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Check workflow files
-        uses: docker://ghcr.io/ponylang/shared-docker-ci-actionlint:20260311
+        uses: docker://ghcr.io/ponylang/shared-docker-ci-actionlint:20260529
         with:
           args: -color

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -74,7 +74,7 @@ jobs:
 
   x86-64-pc-windows-msvc-nightly:
     name: Build and upload x86-64-pc-windows-msvc-nightly
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     steps:
       - name: Disable Windows Defender
         run: Set-MpPreference -DisableRealtimeMonitoring $true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,7 +54,7 @@ jobs:
 
   x86_windows:
     name: x86_64 Windows
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     steps:
       - name: Disable Windows Defender
         run: Set-MpPreference -DisableRealtimeMonitoring $true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
 
   x86-64-pc-windows-msvc-release:
     name: Build and upload x86-64-pc-windows-msvc-release
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     needs:
       - pre-artefact-creation
     steps:


### PR DESCRIPTION
GitHub is redirecting `windows-2025` runner requests to `windows-2025-vs2026` by 2026-06-15. This moves us on our own schedule rather than being silently redirected.

Also bumps the actionlint CI image to `20260529`, whose bundled actionlint recognizes the `windows-2025-vs2026` label so workflow linting continues to pass.