### PR TITLE
Pin cloudsmith-cli below 1.19.0 on arm64 Windows CI

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -122,7 +122,12 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: Build and upload
         run: |
-          python.exe -m pip install --upgrade cloudsmith-cli
+          # Pin cloudsmith-cli below 1.19.0: 1.19.0 added a PyJWT[crypto]
+          # dependency that pulls in cryptography, which has no prebuilt
+          # win_arm64 wheel and fails to build from source on this runner.
+          # Remove once arm64 Windows can install the latest cloudsmith-cli
+          # again.
+          python.exe -m pip install --upgrade "cloudsmith-cli<1.19.0"
           Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,7 +167,12 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: Build and upload
         run: |
-          python.exe -m pip install --upgrade cloudsmith-cli
+          # Pin cloudsmith-cli below 1.19.0: 1.19.0 added a PyJWT[crypto]
+          # dependency that pulls in cryptography, which has no prebuilt
+          # win_arm64 wheel and fails to build from source on this runner.
+          # Remove once arm64 Windows can install the latest cloudsmith-cli
+          # again.
+          python.exe -m pip install --upgrade "cloudsmith-cli<1.19.0"
           Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;


### PR DESCRIPTION
cloudsmith-cli 1.19.0 added a PyJWT[crypto] dependency that pulls in cryptography, which has no prebuilt win_arm64 wheel. pip then builds it from source on the windows-11-arm runners, which needs OpenSSL and fails, breaking the arm64 Windows nightly (and would break the arm64 release the same way).

Pin below 1.19.0 — which resolves to 1.18.0, the last release without the crypto extra — on the arm64 Windows steps only. x86 Windows, Linux, and macOS install the latest fine, so they're left untouched.