### PR TITLE
Make Windows build-and-upload steps fail fast on native command errors

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -81,6 +81,10 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: Build and upload
         run: |
+          # Fail the step on the first failing native command; pwsh treats a
+          # non-zero native exit as non-fatal by default.
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           python.exe -m pip install --upgrade cloudsmith-cli
           Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc;
@@ -90,11 +94,6 @@ jobs:
           .\make.ps1 -Command install;
           .\make.ps1 -Command package;
           $version = (Get-Date).ToString("yyyyMMdd"); cloudsmith push raw --version $version --api-key $env:CLOUDSMITH_API_KEY --summary "Pony dependency manager tool" --description "https://github.com/ponylang/corral" ponylang/nightlies build\corral-x86-64-pc-windows-msvc.zip
-          # Guard the Cloudsmith exit code: in a pwsh step the step's exit
-          # code is that of the last native command, so a failed Cloudsmith
-          # push followed by a successful GHCR push would exit 0 and mask the
-          # failure to the primary download source.
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           # Additionally publish to GHCR, reusing $version so both destinations
           # get the same date.
           python .ci-scripts\release\ghcr_nightly.py push corral x86-64-pc-windows-msvc $version build\corral-x86-64-pc-windows-msvc.zip
@@ -122,6 +121,10 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: Build and upload
         run: |
+          # Fail the step on the first failing native command; pwsh treats a
+          # non-zero native exit as non-fatal by default.
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           # Pin cloudsmith-cli below 1.19.0: 1.19.0 added a PyJWT[crypto]
           # dependency that pulls in cryptography, which has no prebuilt
           # win_arm64 wheel and fails to build from source on this runner.
@@ -136,11 +139,6 @@ jobs:
           .\make.ps1 -Command install;
           .\make.ps1 -Command package;
           $version = (Get-Date).ToString("yyyyMMdd"); cloudsmith push raw --version $version --api-key $env:CLOUDSMITH_API_KEY --summary "Pony dependency manager tool" --description "https://github.com/ponylang/corral" ponylang/nightlies build\corral-arm64-pc-windows-msvc.zip
-          # Guard the Cloudsmith exit code: in a pwsh step the step's exit
-          # code is that of the last native command, so a failed Cloudsmith
-          # push followed by a successful GHCR push would exit 0 and mask the
-          # failure to the primary download source.
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           # Additionally publish to GHCR, reusing $version so both destinations
           # get the same date.
           python .ci-scripts\release\ghcr_nightly.py push corral arm64-pc-windows-msvc $version build\corral-arm64-pc-windows-msvc.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,10 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: Build and upload
         run: |
+          # Fail the step on the first failing native command; pwsh treats a
+          # non-zero native exit as non-fatal by default.
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           python.exe -m pip install --upgrade cloudsmith-cli
           Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc;
@@ -149,7 +153,6 @@ jobs:
           .\make.ps1 -Command install;
           .\make.ps1 -Command package;
           $version = (Get-Content .\VERSION); cloudsmith push raw --version $version --api-key $env:CLOUDSMITH_API_KEY --summary "Pony dependency manager tool" --description "https://github.com/ponylang/corral" ponylang/releases build\corral-x86-64-pc-windows-msvc.zip
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python .ci-scripts\release\github_release.py upload $version build\corral-x86-64-pc-windows-msvc.zip
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
@@ -167,6 +170,10 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: Build and upload
         run: |
+          # Fail the step on the first failing native command; pwsh treats a
+          # non-zero native exit as non-fatal by default.
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           # Pin cloudsmith-cli below 1.19.0: 1.19.0 added a PyJWT[crypto]
           # dependency that pulls in cryptography, which has no prebuilt
           # win_arm64 wheel and fails to build from source on this runner.
@@ -180,7 +187,6 @@ jobs:
           .\make.ps1 -Command install;
           .\make.ps1 -Command package;
           $version = (Get-Content .\VERSION); cloudsmith push raw --version $version --api-key $env:CLOUDSMITH_API_KEY --summary "Pony dependency manager tool" --description "https://github.com/ponylang/corral" ponylang/releases build\corral-arm64-pc-windows-msvc.zip
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python .ci-scripts\release\github_release.py upload $version build\corral-arm64-pc-windows-msvc.zip
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}

--- a/make.ps1
+++ b/make.ps1
@@ -53,7 +53,7 @@ else
 
 if ($Version -eq "")
 {
-  $Version = (Get-Content "$rootDir\VERSION") + "-" + (git rev-parse --short --verify HEAD^)
+  $Version = (Get-Content "$rootDir\VERSION") + "-" + (git rev-parse --short --verify HEAD)
 }
 
 Write-Output "Configuration:    $Config"
@@ -95,7 +95,16 @@ function BuildCorral
   {
     if ($binaryTimestamp -lt $file.LastWriteTimeUtc)
     {
-      ponyc "$configFlag" --cpu "$CPU" --output "$buildDir" "$srcDir"
+      # Build the arg list so $configFlag is genuinely absent when empty.
+      # pwsh 7 passes a quoted-or-unquoted empty variable to native commands as
+      # a literal empty string, which ponyc reads as a second positional package
+      # path ("") and fails with "no source files in package ''" after a
+      # successful link.
+      $ponycArgs = @()
+      if ($configFlag) { $ponycArgs += $configFlag }
+      $ponycArgs += @("--cpu", "$CPU", "--output", "$buildDir", "$srcDir")
+      ponyc @ponycArgs
+      if ($LastExitCode -ne 0) { throw "Error" }
       break buildFiles
     }
   }
@@ -115,8 +124,12 @@ function BuildTest
     if ($testTimestamp -lt $file.LastWriteTimeUtc)
     {
       $testDir = Join-Path -Path $srcDir -ChildPath "test"
-      Write-Output "ponyc `"$configFlag`" --cpu `"$CPU`" --output `"$buildDir`" --bin-name `"test`" `"$testDir`""
-      ponyc "$configFlag" --cpu "$CPU" --output "$buildDir" --bin-name test "$testDir"
+      $ponycArgs = @()
+      if ($configFlag) { $ponycArgs += $configFlag }
+      $ponycArgs += @("--cpu", "$CPU", "--output", "$buildDir", "--bin-name", "test", "$testDir")
+      Write-Output "ponyc $ponycArgs"
+      ponyc @ponycArgs
+      if ($LastExitCode -ne 0) { throw "Error" }
       break testFiles
     }
   }
@@ -145,9 +158,11 @@ switch ($Command.ToLower())
     $testFile = (BuildTest)[-1]
 
     & "$testFile" --exclude=integration --sequential
+    if ($LastExitCode -ne 0) { throw "Error" }
 
     $env:CORRAL_BIN = Join-Path -Path $buildDir -ChildPath "corral.exe"
     & "$testFile" --only=integration --sequential
+    if ($LastExitCode -ne 0) { throw "Error" }
     break
   }
 
@@ -157,6 +172,7 @@ switch ($Command.ToLower())
     $testFile = (BuildTest)[-1]
 
     & "$testFile" --exclude=integration --sequential
+    if ($LastExitCode -ne 0) { throw "Error" }
     break
   }
 
@@ -167,6 +183,7 @@ switch ($Command.ToLower())
 
     $env:CORRAL_BIN = Join-Path -Path $buildDir -ChildPath "corral.exe"
     & "$testFile" --only=integration --sequential
+    if ($LastExitCode -ne 0) { throw "Error" }
     break
   }
 


### PR DESCRIPTION
The Windows `Build and upload` steps in `nightlies.yml` and `release.yml` run a chain of native commands in a single pwsh block — `pip install`, the ponyc download, the `make.ps1` build/test/install/package commands, then the Cloudsmith push — with a `$LASTEXITCODE` guard only after the push. In pwsh a non-zero exit from a native command is not fatal by default, so a failure in an earlier command did not stop the step; it ran on and the real error got buried until the guard fired much later.

Two complementary changes make Windows CI fail at the point of failure:

- The four Build and upload blocks set `$ErrorActionPreference = 'Stop'` and `$PSNativeCommandUseErrorActionPreference = $true` at the top, turning native non-zero exits into terminating errors. This catches the `pip install` (the original failure) and the Cloudsmith push directly, so the manual `$LASTEXITCODE` guard is removed.

- `make.ps1` now guards every native call (`ponyc` and the test binary) with an explicit `$LastExitCode` check, mirroring ponyup's `make.ps1`. This is what fails the build and test steps — and crucially it also covers `pr.yml` and the Windows breakage workflow, which call `make.ps1` without the block-level preferences, plus local `.\make.ps1` runs. (The explicit check is robust to those workflows' `2>&1` redirect, since `$LastExitCode` is unaffected by stream merging.) The block-level preference and the in-script guards are independent mechanisms — correctness does not depend on preference inheritance into the called script.

While making the build fail fast, `make.ps1`'s version line used `git rev-parse --short --verify HEAD^`, whose parent ref does not resolve in the shallow `actions/checkout` clone (verified against a CI log: `fatal: Needed a single revision`, `Version: 0.9.2-`). The failure was silently swallowed before, but would become a hard build break once make.ps1 fails fast. Switched to `HEAD`, which always resolves and matches the canonical Makefile.

Note: the fix relies on the runners executing `run:` steps under pwsh >= 7.4, where `$PSNativeCommandUseErrorActionPreference` is a settable preference. Modern Windows runner images ship this; worth eyeballing the first post-merge `windows-11-arm` run.

Follow-up filed as #333: the Windows build embeds a `-<sha>`-suffixed version string the Makefile doesn't (pre-existing; surfaced more clearly by the `HEAD` fix).

Closes #331