### PR TITLE
Align Windows `corral version` string with Linux and macOS

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -85,18 +85,23 @@ jobs:
           # non-zero native exit as non-fatal by default.
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
+          # Pass -Version explicitly so the embedded version string matches
+          # the Linux/macOS nightly scripts, which pass `version=nightly-<date>`
+          # to make. Without this, make.ps1 falls back to "<VERSION>-<sha>".
+          $cloudsmithVersion = (Get-Date).ToString("yyyyMMdd")
+          $applicationVersion = "nightly-$cloudsmithVersion"
           python.exe -m pip install --upgrade cloudsmith-cli
           Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
-          .\make.ps1 -Command build;
+          .\make.ps1 -Command build -Version $applicationVersion;
           .\make.ps1 -Command test;
           .\make.ps1 -Command install;
           .\make.ps1 -Command package;
-          $version = (Get-Date).ToString("yyyyMMdd"); cloudsmith push raw --version $version --api-key $env:CLOUDSMITH_API_KEY --summary "Pony dependency manager tool" --description "https://github.com/ponylang/corral" ponylang/nightlies build\corral-x86-64-pc-windows-msvc.zip
-          # Additionally publish to GHCR, reusing $version so both destinations
-          # get the same date.
-          python .ci-scripts\release\ghcr_nightly.py push corral x86-64-pc-windows-msvc $version build\corral-x86-64-pc-windows-msvc.zip
+          cloudsmith push raw --version $cloudsmithVersion --api-key $env:CLOUDSMITH_API_KEY --summary "Pony dependency manager tool" --description "https://github.com/ponylang/corral" ponylang/nightlies build\corral-x86-64-pc-windows-msvc.zip
+          # Additionally publish to GHCR, reusing the date so both destinations
+          # get the same value.
+          python .ci-scripts\release\ghcr_nightly.py push corral x86-64-pc-windows-msvc $cloudsmithVersion build\corral-x86-64-pc-windows-msvc.zip
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -125,6 +130,11 @@ jobs:
           # non-zero native exit as non-fatal by default.
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
+          # Pass -Version explicitly so the embedded version string matches
+          # the Linux/macOS nightly scripts, which pass `version=nightly-<date>`
+          # to make. Without this, make.ps1 falls back to "<VERSION>-<sha>".
+          $cloudsmithVersion = (Get-Date).ToString("yyyyMMdd")
+          $applicationVersion = "nightly-$cloudsmithVersion"
           # Pin cloudsmith-cli below 1.19.0: 1.19.0 added a PyJWT[crypto]
           # dependency that pulls in cryptography, which has no prebuilt
           # win_arm64 wheel and fails to build from source on this runner.
@@ -134,14 +144,14 @@ jobs:
           Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
-          .\make.ps1 -Command build;
+          .\make.ps1 -Command build -Version $applicationVersion;
           .\make.ps1 -Command test;
           .\make.ps1 -Command install;
           .\make.ps1 -Command package;
-          $version = (Get-Date).ToString("yyyyMMdd"); cloudsmith push raw --version $version --api-key $env:CLOUDSMITH_API_KEY --summary "Pony dependency manager tool" --description "https://github.com/ponylang/corral" ponylang/nightlies build\corral-arm64-pc-windows-msvc.zip
-          # Additionally publish to GHCR, reusing $version so both destinations
-          # get the same date.
-          python .ci-scripts\release\ghcr_nightly.py push corral arm64-pc-windows-msvc $version build\corral-arm64-pc-windows-msvc.zip
+          cloudsmith push raw --version $cloudsmithVersion --api-key $env:CLOUDSMITH_API_KEY --summary "Pony dependency manager tool" --description "https://github.com/ponylang/corral" ponylang/nightlies build\corral-arm64-pc-windows-msvc.zip
+          # Additionally publish to GHCR, reusing the date so both destinations
+          # get the same value.
+          python .ci-scripts\release\ghcr_nightly.py push corral arm64-pc-windows-msvc $cloudsmithVersion build\corral-arm64-pc-windows-msvc.zip
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,15 +145,19 @@ jobs:
           # non-zero native exit as non-fatal by default.
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
+          # Pass -Version explicitly so the embedded version string matches
+          # the Linux/macOS release scripts, which pass `version=` to make.
+          # Without this, make.ps1 falls back to "<VERSION>-<sha>".
+          $applicationVersion = (Get-Content .\VERSION)
           python.exe -m pip install --upgrade cloudsmith-cli
           Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
-          .\make.ps1 -Command build;
+          .\make.ps1 -Command build -Version $applicationVersion;
           .\make.ps1 -Command install;
           .\make.ps1 -Command package;
-          $version = (Get-Content .\VERSION); cloudsmith push raw --version $version --api-key $env:CLOUDSMITH_API_KEY --summary "Pony dependency manager tool" --description "https://github.com/ponylang/corral" ponylang/releases build\corral-x86-64-pc-windows-msvc.zip
-          python .ci-scripts\release\github_release.py upload $version build\corral-x86-64-pc-windows-msvc.zip
+          cloudsmith push raw --version $applicationVersion --api-key $env:CLOUDSMITH_API_KEY --summary "Pony dependency manager tool" --description "https://github.com/ponylang/corral" ponylang/releases build\corral-x86-64-pc-windows-msvc.zip
+          python .ci-scripts\release\github_release.py upload $applicationVersion build\corral-x86-64-pc-windows-msvc.zip
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
@@ -174,6 +178,10 @@ jobs:
           # non-zero native exit as non-fatal by default.
           $ErrorActionPreference = 'Stop'
           $PSNativeCommandUseErrorActionPreference = $true
+          # Pass -Version explicitly so the embedded version string matches
+          # the Linux/macOS release scripts, which pass `version=` to make.
+          # Without this, make.ps1 falls back to "<VERSION>-<sha>".
+          $applicationVersion = (Get-Content .\VERSION)
           # Pin cloudsmith-cli below 1.19.0: 1.19.0 added a PyJWT[crypto]
           # dependency that pulls in cryptography, which has no prebuilt
           # win_arm64 wheel and fails to build from source on this runner.
@@ -183,11 +191,11 @@ jobs:
           Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
-          .\make.ps1 -Command build;
+          .\make.ps1 -Command build -Version $applicationVersion;
           .\make.ps1 -Command install;
           .\make.ps1 -Command package;
-          $version = (Get-Content .\VERSION); cloudsmith push raw --version $version --api-key $env:CLOUDSMITH_API_KEY --summary "Pony dependency manager tool" --description "https://github.com/ponylang/corral" ponylang/releases build\corral-arm64-pc-windows-msvc.zip
-          python .ci-scripts\release\github_release.py upload $version build\corral-arm64-pc-windows-msvc.zip
+          cloudsmith push raw --version $applicationVersion --api-key $env:CLOUDSMITH_API_KEY --summary "Pony dependency manager tool" --description "https://github.com/ponylang/corral" ponylang/releases build\corral-arm64-pc-windows-msvc.zip
+          python .ci-scripts\release\github_release.py upload $applicationVersion build\corral-arm64-pc-windows-msvc.zip
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.release-notes/align-windows-version-string.md
+++ b/.release-notes/align-windows-version-string.md
@@ -1,0 +1,3 @@
+## Align Windows `corral version` string with Linux and macOS
+
+On Windows, `corral version` now reports the same version string as Linux and macOS builds. Previously, Windows release artifacts reported `<version>-<sha>` instead of `<version>`, and Windows nightly artifacts reported `<version>-<sha>` instead of `nightly-<date>`.


### PR DESCRIPTION
The Linux and macOS release/nightly scripts pass an explicit `version=` to `make`, so the embedded version string is exactly what they pass: `<VERSION>` for releases and `nightly-<date>` for nightlies. The Windows workflows called `make.ps1` without `-Version`, so it fell into its default branch and embedded `<VERSION>-<sha>`. Same source, different version string per platform.

Pass `-Version` to the four Windows build steps so the embedded string matches Linux/macOS. The cloudsmith and GHCR upload versions are unchanged, kept distinct from the embedded value (the date alone for nightly uploads, matching Linux's `CLOUDSMITH_VERSION`).

Closes #333