### PR TITLE
Shuffle test order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,13 +80,13 @@ $(tests_binary): $(GEN_FILES) $(SOURCE_FILES) $(TEST_FILES) | $(BUILD_DIR)
 	${PONYC} $(arch_arg) $(LINKER) --debug -o ${BUILD_DIR} $(SRC_DIR)/test
 
 unit-tests: $(tests_binary)
-	$^ --exclude=integration
+	$^ --exclude=integration --shuffle
 
 test-one: $(tests_binary)
 	$^ --only="$(t)"
 
 integration: $(binary) $(tests_binary)
-	CORRAL_BIN=$$(pwd)/$(binary) $(tests_binary) --only=integration --sequential
+	CORRAL_BIN=$$(pwd)/$(binary) $(tests_binary) --only=integration --sequential --shuffle
 
 test: unit-tests integration
 


### PR DESCRIPTION
Add `--shuffle` to the test runs so tests execute in a randomized order, which surfaces hidden dependencies between tests.
