### PR TITLE
Stop disabling Windows Defender in CI

### DIFF
--- a/.github/workflows/breakage-against-windows-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-windows-ponyc-latest.yml
@@ -12,8 +12,6 @@ jobs:
     name: Verify main against the latest ponyc on Windows
     runs-on: windows-2025-vs2026
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Test with most recent ponyc nightly
         run: |

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -76,8 +76,6 @@ jobs:
     name: Build and upload x86-64-pc-windows-msvc-nightly
     runs-on: windows-2025-vs2026
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Build and upload
         run: |
@@ -121,8 +119,6 @@ jobs:
     name: Build and upload arm64-pc-windows-msvc-nightly
     runs-on: windows-11-arm
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Build and upload
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -56,8 +56,6 @@ jobs:
     name: x86_64 Windows
     runs-on: windows-2025-vs2026
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Test with most recent ponyc release
         run: |
@@ -70,8 +68,6 @@ jobs:
     name: arm64 Windows
     runs-on: windows-11-arm
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Test with most recent ponyc release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,8 +136,6 @@ jobs:
     needs:
       - pre-artefact-creation
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Build and upload
         run: |
@@ -169,8 +167,6 @@ jobs:
     needs:
       - pre-artefact-creation
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Build and upload
         run: |


### PR DESCRIPTION
Remove the "Disable Windows Defender" step from the Windows CI jobs. It doesn't speed the jobs up, and the step occasionally fails on some runners.
