### PR TITLE
Narrow bot workflow triggers to main branch only

### DIFF
--- a/.github/workflows/changelog-bot.yml
+++ b/.github/workflows/changelog-bot.yml
@@ -3,7 +3,7 @@ name: Changelog Bot
 on:
   push:
     branches:
-      - '**'
+      - main
     tags-ignore:
       - '**'
     paths-ignore:

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -3,7 +3,7 @@ name: Release Notes
 on:
   push:
     branches:
-      - '**'
+      - main
     tags-ignore:
       - '**'
     paths-ignore:


### PR DESCRIPTION
The changelog-bot and release-notes-bot workflows triggered on pushes to all branches, but they only do real work on main — the entrypoint scripts exit early on any push that isn't from a merged PR. Running on every feature branch push just burns Actions minutes for nothing.