### PR TITLE
Update for ponyc 0.69.0

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Pull Docker image
-        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
       - name: Build and upload
         run: |
           docker run --rm \
@@ -34,7 +34,7 @@ jobs:
             -e GITHUB_REPOSITORY=${{ github.repository }} \
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -e GITHUB_ACTOR=${{ github.actor }} \
-            ghcr.io/ponylang/shared-docker-ci-standard-builder:release \
+            ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly \
             bash .ci-scripts/release/arm64-unknown-linux-nightly.bash
       - name: Send alert on failure
         if: ${{ failure() }}
@@ -52,7 +52,7 @@ jobs:
     name: Build and upload x86-64-unknown-linux-nightly
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Build and upload
@@ -89,7 +89,7 @@ jobs:
           $cloudsmithVersion = (Get-Date).ToString("yyyyMMdd")
           $applicationVersion = "nightly-$cloudsmithVersion"
           python.exe -m pip install --upgrade cloudsmith-cli
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command build -Version $applicationVersion;
@@ -137,7 +137,7 @@ jobs:
           # Remove once arm64 Windows can install the latest cloudsmith-cli
           # again.
           python.exe -m pip install --upgrade "cloudsmith-cli<1.19.0"
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command build -Version $applicationVersion;
@@ -169,7 +169,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install ponyc
-        run: bash .ci-scripts/macos-x86-install-pony-tools.bash release
+        run: bash .ci-scripts/macos-x86-install-pony-tools.bash nightly
       - name: brew install dependencies
         run: brew install coreutils
       - name: pip install dependencies
@@ -199,7 +199,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install ponyc
-        run: bash .ci-scripts/macos-arm64-install-pony-tools.bash release
+        run: bash .ci-scripts/macos-arm64-install-pony-tools.bash nightly
       - name: brew install dependencies
         run: brew install coreutils
       - name: pip install dependencies

--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -17,7 +17,7 @@ jobs:
     name: Lint Pony source
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,10 +21,10 @@ jobs:
     name: x86_64 Linux
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
-      - name: Test with most recent ponyc release
+      - name: Test with most recent ponyc nightly
         run: make test
 
   # Currently, GitHub actions supplied by GH like checkout and cache do not work
@@ -43,13 +43,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Pull Docker image
-        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder:release
-      - name: Test with most recent ponyc release
+        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
+      - name: Test with most recent ponyc nightly
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/root/project \
             -w /root/project \
-            ghcr.io/ponylang/shared-docker-ci-standard-builder:release \
+            ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly \
             make test
 
   x86_windows:
@@ -57,9 +57,9 @@ jobs:
     runs-on: windows-2025-vs2026
     steps:
       - uses: actions/checkout@v6.0.2
-      - name: Test with most recent ponyc release
+      - name: Test with most recent ponyc nightly
         run: |
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command test 2>&1
@@ -69,9 +69,9 @@ jobs:
     runs-on: windows-11-arm
     steps:
       - uses: actions/checkout@v6.0.2
-      - name: Test with most recent ponyc release
+      - name: Test with most recent ponyc nightly
         run: |
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command test 2>&1
@@ -82,10 +82,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install ponyc
-        run: bash .ci-scripts/macos-x86-install-pony-tools.bash release
+        run: bash .ci-scripts/macos-x86-install-pony-tools.bash nightly
       - name: brew install dependencies
         run: brew install coreutils
-      - name: Test with most recent ponyc release
+      - name: Test with most recent ponyc nightly
         run: |
           export PATH="/tmp/ponyc/bin/:$PATH"
           make test
@@ -96,10 +96,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install ponyc
-        run: bash .ci-scripts/macos-arm64-install-pony-tools.bash release
+        run: bash .ci-scripts/macos-arm64-install-pony-tools.bash nightly
       - name: brew install dependencies
         run: brew install coreutils
-      - name: Test with most recent ponyc release
+      - name: Test with most recent ponyc nightly
         run: |
           export PATH="/tmp/ponyc/bin/:$PATH"
           make test

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ ponyup update corral release
 
 ## Building From Source
 
+You will need ponyc 0.69.0 or newer to build corral from source.
+
 See [BUILD.md](BUILD.md)
 
 ## Getting started using Corral

--- a/corral/util/action.pony
+++ b/corral/util/action.pony
@@ -196,7 +196,7 @@ class val ActionResult
 
 primitive Runner
   """
-  Run an Action using ProcessMonitor, and pass the
+  Run an Action using StartProcess, and pass the
   resulting ActionResult to a given lambda.
   """
 
@@ -207,7 +207,8 @@ primitive Runner
     """
     Execute the action and deliver the result.
     """
-    let c = _Collector(consume result)
+    let sink = _ResultSink(consume result)
+    let c = _Collector(sink)
     let argv: Array[String] iso =
       recover argv.create(action.args.size() + 1) end
     let appname =
@@ -222,28 +223,42 @@ primitive Runner
       end
     argv.push(appname)
     argv.append(action.args)
-    let pm =
-      ProcessMonitor(
-        action.prog.process_auth,
-        action.prog.backpressure_auth,
-        consume c,
-        action.prog.path,
-        consume argv,
-        action.vars,
-        try action.cwd as FilePath end)
-    pm.done_writing()
+    match \exhaustive\ StartProcess(
+      action.prog.process_auth,
+      action.prog.backpressure_auth,
+      consume c,
+      action.prog.path,
+      consume argv,
+      action.vars,
+      try action.cwd as FilePath end)
+    | let pm: ProcessMonitor =>
+      pm.done_writing()
+    | let err: ProcessError =>
+      sink.deliver(ActionResult.fail(err.string()))
+    end
+
+actor \nodoc\ _ResultSink
+  var _result: ({(ActionResult)} ref | None)
+
+  new create(result: {(ActionResult)} iso) =>
+    _result = consume result
+
+  be deliver(ar: ActionResult) =>
+    match _result = None
+    | let r: {(ActionResult)} ref => r(ar)
+    end
 
 class _Collector is ProcessNotify
   """
   Collect Action output and exit into an ActionResult
-  and hand it to the given lambda when ready.
+  and deliver it via _ResultSink.
   """
   let _stdout: String iso = recover String end
   let _stderr: String iso = recover String end
-  let _result: {(ActionResult)} iso
+  let _sink: _ResultSink tag
 
-  new iso create(result: {(ActionResult)} iso) =>
-    _result = consume result
+  new iso create(sink: _ResultSink tag) =>
+    _sink = sink
 
   fun ref created(
     process: ProcessMonitor ref)
@@ -274,7 +289,7 @@ class _Collector is ProcessNotify
             recover val _stdout.clone() end,
           stderr' =
             recover val _stderr.clone() end)
-    _result(cr)
+    _sink.deliver(cr)
 
   fun ref dispose(
     process: ProcessMonitor ref,
@@ -285,7 +300,7 @@ class _Collector is ProcessNotify
         child_exit_status,
         recover val _stdout.clone() end,
         recover val _stderr.clone() end)
-    _result(cr)
+    _sink.deliver(cr)
 
 // gnu.org/software/libc/manual/html_node/
 // Working-Directory.html


### PR DESCRIPTION
ponyc removed the public `ProcessMonitor` constructor in favor of the `StartProcess` factory, which returns `(ProcessMonitor | ProcessError)`. The call site now matches on the result.

PR and nightly workflows switched from release to nightly ponyc since the `ProcessMonitor` change hasn't been released yet.
